### PR TITLE
feat [DD-005] Added home screen habit list with loading and error states

### DIFF
--- a/daily_done/ContentView.swift
+++ b/daily_done/ContentView.swift
@@ -2,13 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        HabitListView()
     }
 }
 

--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -2,7 +2,7 @@ import FirebaseFirestore
 import Foundation
 
 protocol FirebaseServiceProtocol {
-    func fetchHabits() async throws -> [String: Any]
+    func fetchHabits(userId: String) async throws -> [Habit]
 }
 
 actor FirebaseService: FirebaseServiceProtocol {
@@ -12,11 +12,16 @@ actor FirebaseService: FirebaseServiceProtocol {
 
     private init() {}
 
-    func fetchHabits() async throws -> [String: Any] {
-        // TODO: Replace with typed Habit model when DD-003 lands
-        let snapshot = try await db.collection("habits").getDocuments()
-        return Dictionary(uniqueKeysWithValues: snapshot.documents.map {
-            ($0.documentID, $0.data())
-        })
+    func fetchHabits(userId: String) async throws -> [Habit] {
+        let snapshot =
+            try await db
+            .collection("habits")
+            .whereField("userId", isEqualTo: userId)
+            .getDocuments()
+        return try await MainActor.run {
+            try snapshot.documents.compactMap {
+                try $0.data(as: Habit.self)
+            }
+        }
     }
 }

--- a/daily_done/Utilities/Extensions/Color+Extensions.swift
+++ b/daily_done/Utilities/Extensions/Color+Extensions.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255
+        let g = Double((int >> 8) & 0xFF) / 255
+        let b = Double(int & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}
+

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -1,30 +1,40 @@
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 final class HabitViewModel: ObservableObject {
     @Published var habits: [Habit] = []
     @Published var isLoading: Bool = false
-    @Published var errorMessage: String?
+    @Published var error: HabitError?
 
     private let service: FirebaseServiceProtocol
 
-    init(service: FirebaseServiceProtocol = FirebaseService.shared) {
-        self.service = service
+    init(service: FirebaseServiceProtocol? = nil) {
+        self.service = service ?? FirebaseService.shared
     }
 
-    func fetchHabits() async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            habits = try await service.fetchHabits(userId: "preview-user")
-        } catch {
-            errorMessage = "Could not load habits. Please try again."
-            print(
-                "HabitListViewModel fetchHabits error: \(error.localizedDescription)"
-            )
+    func loadHabits() async {
+            isLoading = true
+            defer { isLoading = false }
+            do {
+                // TODO: Byt till Auth.auth().currentuser....  - senare tillfälle
+                habits = try await service.fetchHabits(userId: "preview-user")
+            } catch let fetchError {
+                error = .loadFailed(fetchError)
+                print("HabitViewModel loadHabits: \(fetchError.localizedDescription)")
+            }
         }
-        isLoading = false
     }
-}
+
+    extension HabitViewModel {
+        enum HabitError: LocalizedError {
+            case loadFailed(Error)
+
+            var errorDescription: String? {
+                switch self {
+                case .loadFailed:
+                    return "Could not load habits. Please try again."
+                }
+            }
+        }
+    }

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Combine
+
+@MainActor
+final class HabitViewModel: ObservableObject {
+    @Published var habits: [Habit] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    private let service: FirebaseServiceProtocol
+
+    init(service: FirebaseServiceProtocol = FirebaseService.shared) {
+        self.service = service
+    }
+
+    func fetchHabits() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            habits = try await service.fetchHabits(userId: "preview-user")
+        } catch {
+            errorMessage = "Could not load habits. Please try again."
+            print(
+                "HabitListViewModel fetchHabits error: \(error.localizedDescription)"
+            )
+        }
+        isLoading = false
+    }
+}

--- a/daily_done/Views/Habits/Components/HabitRowView.swift
+++ b/daily_done/Views/Habits/Components/HabitRowView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct HabitRowView: View {
+    let habit: Habit
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color(hex: habit.colorHex))
+                .frame(width: 40, height: 40)
+                .overlay(
+                    Image(systemName: habit.iconName)
+                        .foregroundStyle(.white)
+                        .font(.system(size: 18, weight: .medium))
+                )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(habit.name)
+                    .font(.headline)
+                Text(habit.category.rawValue.capitalized)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                HStack(spacing: 4) {
+                    Image(systemName: "flame.fill")
+                        .foregroundStyle(.orange)
+                    Text("\(habit.currentStreak)")
+                        .font(.headline)
+                }
+                Text("day streak")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    HabitRowView(habit: .preview)
+        .padding()
+}

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct HabitListView: View {
+    @StateObject private var vm = HabitViewModel()
+    @State private var showCreateSheet = false
+
+    var body: some View {
+        NavigationStack {
+            contentView
+                .navigationTitle("Daily Done")
+                .toolbar { toolbarContent }
+                .sheet(isPresented: $showCreateSheet) {
+                    Text("Create Habit — coming in DD-006")
+                        .padding()
+                }
+                .task {
+                    await vm.loadHabits()
+
+                }
+                .alert(
+                    "Error",
+                    isPresented: Binding(
+                        get: { vm.error != nil },
+                        set: { if !$0 { vm.error = nil } }
+                    )
+                ) {
+                    Button("Retry") { Task { await vm.loadHabits() } }
+                    Button("Dismiss", role: .cancel) { vm.error = nil }
+                } message: {
+                    Text(vm.error?.errorDescription ?? "")
+                }
+        }
+
+    }
+    
+    @ViewBuilder
+    private var contentView: some View {
+        if vm.isLoading {
+            ProgressView("Loading habits..")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }else if vm.habits.isEmpty {
+            ContentUnavailableView(
+                "No Habits Yet",
+                systemImage: "checkmark.circle",
+                description: Text("Tap + to add your first habit")
+            )
+        } else {
+            habitList
+        }
+    }
+    
+    private var habitList: some View {
+          List(vm.habits) { habit in
+              HabitRowView(habit: habit)
+                  .listRowSeparator(.hidden)
+                  .listRowBackground(Color.clear)
+          }
+          .listStyle(.plain)
+      }
+    
+    @ToolbarContentBuilder
+      private var toolbarContent: some ToolbarContent {
+          ToolbarItem(placement: .topBarTrailing) {
+              Button {
+                  showCreateSheet = true
+              } label: {
+                  Label("Add Habit", systemImage: "plus")
+              }
+          }
+      }
+  }
+
+  #Preview {
+      HabitListView()
+  }


### PR DESCRIPTION
## 📝 Description
Implements the main home screen with a NavigationStack + List displaying all habits fetched from Firestore. Covers all four UI states: loading spinner, empty state, error alert with retry, and the populated habit list.

## 🎫 Related Issue
Closes #5

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- Add screenshots after testing on simulator -->

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on iPhone simulator (iOS 17+)
2. Verify the loading spinner appears briefly on launch
3. With no habits in Firestore — confirm "No Habits Yet" empty state is shown with a + button in the toolbar
4. With habits in Firestore — confirm each row shows the habit name, category icon, and streak count
5. Disable network / use airplane mode — confirm the error alert appears with a "Retry" button that re-triggers the fetch

## 💭 Additional Notes
- `userId` is hardcoded to `"preview-user"` — a TODO comment marks this for replacement when Firebase Auth is wired up in a future ticket
- `FirebaseService` uses `actor` for thread safety; decoding runs inside `MainActor.run {}` because Firebase's `@DocumentID` property wrapper requires main-thread context in Swift 6
- The + toolbar button opens a placeholder sheet — full implementation is DD-006
- Named color assets (`brandAccent`, `neutral-dark`) are not yet in Assets.xcassets; the app falls back to system colors until DD-020 (dark mode pass)

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics