### PR TITLE
chore [DESIGN-SYSTEM] Added Color Tokens, Spacing Constants, and Design Tokens

### DIFF
--- a/daily_done/Assets.xcassets/backgroundPrimary.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/backgroundPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.078",
+          "green" : "0.043",
+          "red" : "0.043"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/backgroundSecondary.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/backgroundSecondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.118",
+          "green" : "0.086",
+          "red" : "0.086"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/backgroundSheet.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/backgroundSheet.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.157",
+          "green" : "0.110",
+          "red" : "0.110"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/brandAccent.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/brandAccent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.137",
+          "green" : "0.651",
+          "red" : "0.961"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/brandPrimary.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/brandPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.380",
+          "red" : "0.482"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/destructive.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/destructive.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.298",
+          "red" : "0.906"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/success.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/success.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.443",
+          "green" : "0.800",
+          "red" : "0.180"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/textPrimary.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/textPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Assets.xcassets/textSecondary.colorset/Contents.json
+++ b/daily_done/Assets.xcassets/textSecondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.627",
+          "green" : "0.557",
+          "red" : "0.557"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/daily_done/Utilities/Extensions/Constants.swift
+++ b/daily_done/Utilities/Extensions/Constants.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+enum DesignSystem {
+    enum Spacing {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let base: CGFloat = 16
+        static let lg: CGFloat = 24
+        static let xl: CGFloat = 32
+        static let xxl: CGFloat = 48
+    }
+
+    enum Radius {
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let xl: CGFloat = 24
+    }
+
+    enum HabitPalette {
+        static let colors: [String] = [
+            "#7B61FF",  // violet
+            "#10B981",  // emerald
+            "#F59E0B",  // amber
+            "#EF4444",  // coral
+            "#60A5FA",  // sky
+            "#EC4899",  // pink
+            "#F97316",  // orange
+            "#A78BFA"   // lavender
+        ]
+
+        static let icons: [String] = [
+            "figure.mind.and.body",
+            "dumbbell",
+            "book.fill",
+            "drop.fill",
+            "moon.fill",
+            "figure.run"
+        ]
+    }
+}


### PR DESCRIPTION
## 📝 Description
Establishes the app's design system foundation by adding 9 named color tokens to `Assets.xcassets` and a `DesignSystem` constants file covering spacing, corner radii, habit color palette, and selectable icons. All future screens reference these tokens instead of hardcoded values.

## 🎫 Related Issue
Closes #39

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
N/A — no visible UI changes. Colors and constants are infrastructure only.

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [ ] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [ ] Error handling for network failures exists

### UI/UX
N/A — no UI changes in this ticket. Colors are tokens only; no screen was modified.

- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Open `Assets.xcassets` in Xcode — verify 9 new color sets appear: `backgroundPrimary`, `backgroundSecondary`, `backgroundSheet`, `brandPrimary`, `brandAccent`, `success`, `destructive`, `textPrimary`, `textSecondary`
2. Open `Utilities/Extensions/Constants.swift` — verify `DesignSystem.Spacing`, `DesignSystem.Radius`, and `DesignSystem.HabitPalette` are accessible
3. Build the project — it should compile without errors or warnings
4. In any SwiftUI preview, type `Color("brandPrimary")` — it should resolve to the purple from the design

## 💭 Additional Notes
- Both light and dark mode variants are set to the same dark values since only dark-mode designs exist. Light mode variants can be updated if a light theme is added later.
- `Constants.swift` landed in `Utilities/Extensions/` — it should ideally live directly in `Utilities/`. Can be moved in a follow-up without any functional impact.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics