### PR TITLE
feat [DD-006] Added Create Habit Sheet with Form Validation and Error Handling

### DIFF
--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -3,6 +3,8 @@ import Foundation
 
 protocol FirebaseServiceProtocol {
     func fetchHabits(userId: String) async throws -> [Habit]
+    func createHabit(_ habit: Habit) async throws
+
 }
 
 actor FirebaseService: FirebaseServiceProtocol {
@@ -23,5 +25,13 @@ actor FirebaseService: FirebaseServiceProtocol {
                 try $0.data(as: Habit.self)
             }
         }
+    }
+    
+    func createHabit(_ habit: Habit) async throws {
+        let ref = db.collection("habits").document()
+        let data = try await MainActor.run {
+            try Firestore.Encoder().encode(habit)
+        }
+        try await ref.setData(data)
     }
 }

--- a/daily_done/Utilities/Extensions/Constants.swift
+++ b/daily_done/Utilities/Extensions/Constants.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum DesignSystem {
     enum Spacing {
+        static let xxs: CGFloat = 2
         static let xs: CGFloat = 4
         static let sm: CGFloat = 8
         static let md: CGFloat = 12

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -24,16 +24,50 @@ final class HabitViewModel: ObservableObject {
                 print("HabitViewModel loadHabits: \(fetchError.localizedDescription)")
             }
         }
+    
+    func createHabit (
+        name: String,
+        category: HabitCategory,
+        colorHex: String,
+        iconName: String
+    )async throws {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmedName.isEmpty else {
+            throw HabitError.nameMissing
+        
+        }
+        
+        let habit = Habit(
+            userId: "preview-user",  // Todo: updateras Auth () id senare
+            name: trimmedName,
+            category: category,
+            colorHex: colorHex,
+            iconName: iconName,
+            createdAt: Date(),
+            currentStreak: 0,
+            longestStreak: 0,
+            totalCompletions: 0
+            
+        )
+        try await service.createHabit(habit)
+        habits.append(habit)
+    }
     }
 
     extension HabitViewModel {
         enum HabitError: LocalizedError {
             case loadFailed(Error)
+            case nameMissing
+            case saveFailed(Error)
 
             var errorDescription: String? {
                 switch self {
                 case .loadFailed:
                     return "Could not load habits. Please try again."
+                case .nameMissing:
+                    return "Please enter a name for the habit."
+                case .saveFailed:
+                    return "Could not save habit. Please try again."
                 }
             }
         }

--- a/daily_done/Views/Habits/CreateHabitSheet.swift
+++ b/daily_done/Views/Habits/CreateHabitSheet.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+struct CreateHabitSheet: View {
+    @ObservedObject var vm: HabitViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var selectedCategory: HabitCategory = .health
+    @State private var selectedColorHex = DesignSystem.HabitPalette.colors[0]
+    @State private var selectedIcon = DesignSystem.HabitPalette.icons[0]
+    @State private var reminderEnabled = false
+    @State private var nameError: String?
+    @State private var saveError: String?
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    nameSection
+                    categorySection
+                    colorSection
+                    iconSection
+                    reminderSection
+                }
+                .padding(DesignSystem.Spacing.base)
+            }
+            .background(Color("backgroundSheet"))
+            .navigationTitle("New Habit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Color("textSecondary"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color("brandPrimary"))
+                    .disabled(isSaving)
+                }
+            }
+        }
+    }
+
+    private func saveErrorBanner(message: String) -> some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "exclamationmark.circle")
+            Text(message)
+                .font(.caption)
+        }
+        .foregroundStyle(Color("destructive"))
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color("destructive").opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.sm))
+    }
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("HABIT NAME")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            TextField("Morning run..", text: $name)
+                .padding(DesignSystem.Spacing.md)
+                .background(Color("backgroundSecondary"))
+                .clipShape(
+                    RoundedRectangle(cornerRadius: DesignSystem.Radius.sm)
+                )
+                .foregroundStyle(Color("textPrimary"))
+            if let nameError {
+                Text(nameError)
+                    .font(.caption)
+                    .foregroundStyle(Color("destructive"))
+            }
+        }
+    }
+
+    private var categorySection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("CATEGORY")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    ForEach(HabitCategory.allCases) { category in
+                        Button(category.rawValue.capitalized) {
+                            selectedCategory = category
+                        }
+                        .padding(.horizontal, DesignSystem.Spacing.base)
+                        .padding(.vertical, DesignSystem.Spacing.sm)
+                        .background(
+                            selectedCategory == category
+                                ? Color(hex: selectedColorHex)
+                                : Color("backgroundSecondary")
+                        )
+                        .foregroundStyle(
+                            selectedCategory == category
+                                ? Color("textPrimary")
+                                : Color("textSecondary")
+                        )
+                        .clipShape(Capsule())
+                    }
+                }
+            }
+        }
+    }
+
+    private var colorSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("COLOR")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            HStack(spacing: DesignSystem.Spacing.md) {
+                ForEach(DesignSystem.HabitPalette.colors, id: \.self) { hex in
+                    Circle()
+                        .fill(Color(hex: hex))
+                        .frame(width: 36, height: 36)
+                        .overlay {
+                            if selectedColorHex == hex {
+                                Circle().strokeBorder(
+                                    Color("textPrimary"),
+                                    lineWidth: 3
+                                )
+                            }
+                        }
+                        .onTapGesture { selectedColorHex = hex }
+                }
+            }
+        }
+
+    }
+
+    private var iconSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("ICON")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            HStack(spacing: DesignSystem.Spacing.md) {
+                ForEach(DesignSystem.HabitPalette.icons, id: \.self) { icon in
+                    ZStack {
+                        RoundedRectangle(cornerRadius: DesignSystem.Radius.md)
+                            .fill(
+                                selectedIcon == icon
+                                    ? Color(hex: selectedColorHex)
+                                    : Color("backgroundSecondary")
+                            )
+                            .frame(width: 52, height: 52)
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .foregroundStyle(
+                                selectedIcon == icon
+                                    ? Color("textPrimary")
+                                    : Color("textSecondary")
+                            )
+                            .onTapGesture { selectedIcon = icon }
+                    }
+                }
+            }
+        }
+    }
+
+    private var reminderSection: some View {
+        HStack(spacing: DesignSystem.Spacing.base) {
+            Image(systemName: "bell")
+                .foregroundStyle(Color("textSecondary"))
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxs) {
+                Text("Reminder")
+                    .font(.body)
+                    .foregroundStyle(Color("textPrimary"))
+                Text("Set a daily reminder")
+                    .font(.caption)
+                    .foregroundStyle(Color("textSecondary"))
+            }
+            Spacer()
+            // TODO: Implementera NotificationService kommer i DD-009
+            Toggle("", isOn: $reminderEnabled)
+                .labelsHidden()
+                .tint(Color("brandPrimary"))
+        }
+        .padding(DesignSystem.Spacing.base)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.md))
+    }
+
+    private func save() async {
+        nameError = nil
+        isSaving = true
+        saveError = nil
+        defer { isSaving = false }
+        do {
+            try await vm.createHabit(
+                name: name,
+                category: selectedCategory,
+                colorHex: selectedColorHex,
+                iconName: selectedIcon
+            )
+            dismiss()
+
+        } catch HabitViewModel.HabitError.nameMissing {
+            nameError = "Name is required"
+        } catch {
+            saveError = "Could not save habit. Check your connection and try again."
+        }
+    }
+}
+#Preview {
+    CreateHabitSheet(vm: HabitViewModel())
+}

--- a/daily_done/Views/Habits/CreateHabitSheet.swift
+++ b/daily_done/Views/Habits/CreateHabitSheet.swift
@@ -17,6 +17,9 @@ struct CreateHabitSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    if let saveError {
+                        ErrorBannerView(message: saveError)
+                    }
                     nameSection
                     categorySection
                     colorSection
@@ -43,19 +46,6 @@ struct CreateHabitSheet: View {
                 }
             }
         }
-    }
-
-    private func saveErrorBanner(message: String) -> some View {
-        HStack(spacing: DesignSystem.Spacing.sm) {
-            Image(systemName: "exclamationmark.circle")
-            Text(message)
-                .font(.caption)
-        }
-        .foregroundStyle(Color("destructive"))
-        .padding(DesignSystem.Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color("destructive").opacity(0.12))
-        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.sm))
     }
 
     private var nameSection: some View {
@@ -202,7 +192,8 @@ struct CreateHabitSheet: View {
         } catch HabitViewModel.HabitError.nameMissing {
             nameError = "Name is required"
         } catch {
-            saveError = "Could not save habit. Check your connection and try again."
+            saveError =
+                "Could not save habit. Check your connection and try again."
         }
     }
 }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -9,8 +9,7 @@ struct HabitListView: View {
             .navigationTitle("Daily Done")
             .toolbar { toolbarContent }
             .sheet(isPresented: $showCreateSheet) {
-                Text("Create Habit — coming in DD-006")
-                    .padding()
+                CreateHabitSheet(vm: vm)
             }
             .task {
                 await vm.loadHabits()

--- a/daily_done/Views/Shared/ErrorBannerView.swift
+++ b/daily_done/Views/Shared/ErrorBannerView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ErrorBannerView: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "exclamationmark.circle")
+            Text(message)
+                .font(.caption)
+        }
+        .foregroundStyle(Color("destructive"))
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color("destructive").opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.sm))
+    }
+}
+
+#Preview {
+    ErrorBannerView(message: "Could not save habit. Check your connection and try again.")
+        .padding()
+}


### PR DESCRIPTION
## 📝 Description
Implements the full create habit sheet — a bottom modal with name input, category chips, color picker, and icon picker. Saves to Firestore via `HabitViewModel.createHabit` and updates the habit list immediately via optimistic append. Inline name validation and a shared `ErrorBannerView` handle all error states.

## 🎫 Related Issue
Closes #6

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- Add screenshots after testing on simulator -->

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on simulator — tap the **+** button in the top-right of the Habits tab
2. Verify the sheet slides up with: name field, category chips, 8 color circles, 6 icon buttons, reminder toggle
3. Tap **Save** with an empty name — verify inline error appears under the name field
4. Fill in a name, pick a category, color, and icon — tap **Save** — verify the sheet dismisses and the new habit appears in the list
5. To test the error banner: turn off WiFi, fill in a valid name, tap **Save** — verify the red banner appears at the top of the form
6. Tap **Cancel** at any point — verify the sheet dismisses without saving anything

## 💭 Additional Notes
- `ErrorBannerView` extracted to `Views/Shared/` — reusable across any future sheet or screen that needs a form-level error banner
- `createHabit` uses optimistic local append — the list updates instantly without waiting for a Firestore re-fetch
- Firestore encoding uses `MainActor.run { Firestore.Encoder().encode(habit) }` to satisfy Swift 6 actor isolation — `@DocumentID` ties `Habit`'s `Encodable` conformance to the main actor
- `userId` is hardcoded as `"preview-user"` — will be replaced with `Auth.auth().currentUser?.uid` in the auth ticket
- Reminder toggle is interactive but not yet wired up — `NotificationService` comes in DD-009

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [x] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics