### PR TITLE
feat [DD-007] Marked habit as complete for today

### DIFF
--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -26,7 +26,7 @@ actor FirebaseService: FirebaseServiceProtocol {
             }
         }
     }
-    
+
     func createHabit(_ habit: Habit) async throws {
         let ref = db.collection("habits").document()
         let data = try await MainActor.run {
@@ -34,4 +34,41 @@ actor FirebaseService: FirebaseServiceProtocol {
         }
         try await ref.setData(data)
     }
+
+    func habitLogComplition(habitId: String, userId: String) async throws {
+
+        let log = HabitLog(
+            id: UUID().uuidString,
+            habitId: habitId,
+            userId: userId,
+            completedAt: Date(),
+            location: nil
+        )
+        let ref = db.collection("habitLogs").document()
+        let data = try await MainActor.run {
+            try Firestore.Encoder().encode(log)
+        }
+        try await ref.setData(data)
+    }
+    
+    func fetchTodayLogs (userId: String) async throws -> [HabitLog] {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: Date())
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
+        
+        let snapshot = try await db
+            .collection("habitLogs")
+            .whereField("userId", isEqualTo: userId)
+            .whereField("completedAt", isGreaterThanOrEqualTo: startOfDay)
+            .whereField("completedAt", isLessThan: endOfDay ) // undersök varning innan push
+            .getDocuments()
+        
+        return try await MainActor.run {
+            try snapshot.documents.compactMap{
+                try $0.data(as: HabitLog.self)
+            }
+        }
+        
+    }
+
 }

--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -4,7 +4,8 @@ import Foundation
 protocol FirebaseServiceProtocol {
     func fetchHabits(userId: String) async throws -> [Habit]
     func createHabit(_ habit: Habit) async throws
-
+    func habitLogComplition(habitId: String, userId: String) async throws
+     func fetchTodayLogs(userId: String) async throws -> [HabitLog]
 }
 
 actor FirebaseService: FirebaseServiceProtocol {

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -6,6 +6,7 @@ final class HabitViewModel: ObservableObject {
     @Published var habits: [Habit] = []
     @Published var isLoading: Bool = false
     @Published var error: HabitError?
+    @Published var completedHabitIds: Set<String> = []
 
     private let service: FirebaseServiceProtocol
 
@@ -14,29 +15,40 @@ final class HabitViewModel: ObservableObject {
     }
 
     func loadHabits() async {
-            isLoading = true
-            defer { isLoading = false }
-            do {
-                // TODO: Byt till Auth.auth().currentuser....  - senare tillfälle
-                habits = try await service.fetchHabits(userId: "preview-user")
-            } catch let fetchError {
-                error = .loadFailed(fetchError)
-                print("HabitViewModel loadHabits: \(fetchError.localizedDescription)")
-            }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            async let fetchedHabits = service.fetchHabits(
+                userId: "preview-user"
+            )
+            async let fetchedLogs = service.fetchTodayLogs(
+                userId: "preview-user"
+            )
+            let (loadedHabits, todayLogs) = try await (
+                fetchedHabits, fetchedLogs
+            )
+            habits = loadedHabits
+            completedHabitIds = Set(todayLogs.compactMap { $0.habitId })
+        } catch let fetchError {
+            error = .loadFailed(fetchError)
+            print(
+                "HabitViewModel loadHabits: \(fetchError.localizedDescription)"
+            )
         }
-    
-    func createHabit (
+    }
+
+    func createHabit(
         name: String,
         category: HabitCategory,
         colorHex: String,
         iconName: String
-    )async throws {
+    ) async throws {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         guard !trimmedName.isEmpty else {
             throw HabitError.nameMissing
-        
+
         }
-        
+
         let habit = Habit(
             userId: "preview-user",  // Todo: updateras Auth () id senare
             name: trimmedName,
@@ -47,28 +59,47 @@ final class HabitViewModel: ObservableObject {
             currentStreak: 0,
             longestStreak: 0,
             totalCompletions: 0
-            
+
         )
         try await service.createHabit(habit)
         habits.append(habit)
     }
+
+    func toggleCompletion(for habit: Habit) async {
+        guard let habitId = habit.id else { return }
+        guard !completedHabitIds.contains(habitId) else { return }
+        completedHabitIds.insert(habitId)
+
+        do {
+            try await service.habitLogComplition(
+                habitId: habitId,
+                userId: habit.userId
+            )
+        } catch let saveError {
+            completedHabitIds.remove(habitId)
+            error = .saveFailed(saveError)
+            print(
+                "HabitViewModel toggleCompletion: \(saveError.localizedDescription)"
+            )
+        }
     }
+}
 
-    extension HabitViewModel {
-        enum HabitError: LocalizedError {
-            case loadFailed(Error)
-            case nameMissing
-            case saveFailed(Error)
+extension HabitViewModel {
+    enum HabitError: LocalizedError {
+        case loadFailed(Error)
+        case nameMissing
+        case saveFailed(Error)
 
-            var errorDescription: String? {
-                switch self {
-                case .loadFailed:
-                    return "Could not load habits. Please try again."
-                case .nameMissing:
-                    return "Please enter a name for the habit."
-                case .saveFailed:
-                    return "Could not save habit. Please try again."
-                }
+        var errorDescription: String? {
+            switch self {
+            case .loadFailed:
+                return "Could not load habits. Please try again."
+            case .nameMissing:
+                return "Please enter a name for the habit."
+            case .saveFailed:
+                return "Could not save habit. Please try again."
             }
         }
     }
+}

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -17,22 +17,25 @@ final class HabitViewModel: ObservableObject {
     func loadHabits() async {
         isLoading = true
         defer { isLoading = false }
+
         do {
-            async let fetchedHabits = service.fetchHabits(
-                userId: "preview-user"
-            )
-            async let fetchedLogs = service.fetchTodayLogs(
-                userId: "preview-user"
-            )
-            let (loadedHabits, todayLogs) = try await (
-                fetchedHabits, fetchedLogs
-            )
-            habits = loadedHabits
-            completedHabitIds = Set(todayLogs.compactMap { $0.habitId })
+            habits = try await service.fetchHabits(userId: "preview-user")
         } catch let fetchError {
             error = .loadFailed(fetchError)
             print(
-                "HabitViewModel loadHabits: \(fetchError.localizedDescription)"
+                "HabitViewModel fetchHabits failed: \(fetchError.localizedDescription)"
+            )
+            return
+        }
+
+        do {
+            let todayLogs = try await service.fetchTodayLogs(
+                userId: "preview-user"
+            )
+            completedHabitIds = Set(todayLogs.compactMap { $0.habitId })
+        } catch let logError {
+            print(
+                "HabitViewModel fetchTodayLogs failed: \(logError.localizedDescription)"
             )
         }
     }

--- a/daily_done/Views/Habits/Components/HabitRowView.swift
+++ b/daily_done/Views/Habits/Components/HabitRowView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct HabitRowView: View {
     let habit: Habit
+    let isCompleted: Bool
+    let onToggle: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -17,6 +19,7 @@ struct HabitRowView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(habit.name)
                     .font(.headline)
+                    .strikethrough(isCompleted, color: .secondary)
                 Text(habit.category.rawValue.capitalized)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -35,12 +38,29 @@ struct HabitRowView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
+
+            Button(action: onToggle) {
+                Image(
+                    systemName: isCompleted ? "checkmark.circle.fill" : "circle"
+                )
+                .font(.title2)
+                .foregroundStyle(
+                    isCompleted ? Color("brandPrimary") : .secondary
+                )
+                .animation(.easeInOut(duration: 0.15), value: isCompleted)
+            }
+            .disabled(isCompleted)
+            .buttonStyle(.plain)
         }
-        .padding(.vertical, 8)
     }
 }
 
 #Preview {
-    HabitRowView(habit: .preview)
-        .padding()
+    VStack(spacing: 0) {
+        HabitRowView(habit: .preview, isCompleted: false, onToggle: {})
+            .padding()
+        Divider()
+        HabitRowView(habit: .preview, isCompleted: true, onToggle: {})
+            .padding()
+    }
 }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -48,9 +48,13 @@ struct HabitListView: View {
 
     private var habitList: some View {
         List(vm.habits) { habit in
-            HabitRowView(habit: habit)
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+            HabitRowView(
+                habit: habit,
+                isCompleted: vm.completedHabitIds.contains(habit.id ?? ""),
+                onToggle: { Task { await vm.toggleCompletion(for: habit) } }
+            )
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
         }
         .listStyle(.plain)
     }


### PR DESCRIPTION
## 📝 Description
Adds the ability to mark a habit as done for today by tapping a circle button on the habit row. A HabitLog entry is written to Firestore and the completed state is reflected immediately in the UI with an optimistic update.

## 🎫 Related Issue
Closes #7

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- Add screenshots after testing on simulator -->

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [x] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest main
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Launch the app — habits load with an empty circle button on the right of each row
2. Tap the circle on any habit row — it should instantly fill with a green checkmark and the habit name gets a strikethrough
3. Tap the same circle again — nothing should happen (button is disabled after completion)
4. Kill and relaunch the app — the completed state should still show (loaded from Firestore)
5. Force an error by disabling network and tapping complete — verify an error alert appears and the circle reverts to empty

## 💭 Additional Notes
- userId is still hardcoded as "preview-user" — will be replaced when Auth is wired up in a later ticket
- Firebase Security Rules for the new habitLogs collection should be reviewed before production
- Streak counter update on completion is not part of this ticket

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [x] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics