### PR TITLE
feat [DD-008] Added StreakCalculator and wire streak calculation into HabitViewModel

### DIFF
--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -6,6 +6,7 @@ protocol FirebaseServiceProtocol {
     func createHabit(_ habit: Habit) async throws
     func habitLogComplition(habitId: String, userId: String) async throws
      func fetchTodayLogs(userId: String) async throws -> [HabitLog]
+    func fetchAllLogs(userId: String) async throws -> [HabitLog]
 }
 
 actor FirebaseService: FirebaseServiceProtocol {
@@ -56,20 +57,34 @@ actor FirebaseService: FirebaseServiceProtocol {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: Date())
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
-        
+
         let snapshot = try await db
             .collection("habitLogs")
             .whereField("userId", isEqualTo: userId)
             .whereField("completedAt", isGreaterThanOrEqualTo: startOfDay)
             .whereField("completedAt", isLessThan: endOfDay ) // undersök varning innan push
             .getDocuments()
-        
+
         return try await MainActor.run {
             try snapshot.documents.compactMap{
                 try $0.data(as: HabitLog.self)
             }
         }
-        
+
+    }
+
+    func fetchAllLogs(userId: String) async throws -> [HabitLog] {
+        let snapshot = try await db
+            .collection("habitLogs")
+            .whereField("userId", isEqualTo: userId)
+            .order(by: "completedAt", descending: true)
+            .getDocuments()
+
+        return try await MainActor.run {
+            try snapshot.documents.compactMap {
+                try $0.data(as: HabitLog.self)
+            }
+        }
     }
 
 }

--- a/daily_done/Utilities/Helpers/StreakCalculator.swift
+++ b/daily_done/Utilities/Helpers/StreakCalculator.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum StreakCalculator {
+
+    static func currentStreak(from logs: [HabitLog]) -> Int {
+        let days = completedDays(from: logs)
+        guard !days.isEmpty else { return 0 }
+
+        var streak = 0
+
+        var expectedDay = Calendar.current.startOfDay(for: Date())
+
+        for day in days {
+            if day == expectedDay {
+                streak += 1
+                expectedDay = Calendar.current.date(byAdding: .day, value: -1, to: expectedDay)!
+            } else {
+                break
+            }
+        }
+        return streak
+    }
+
+    static func longestStreak(from logs: [HabitLog]) -> Int {
+        let days = completedDays(from: logs)
+        guard days.count > 0 else { return 0 }
+
+        var longest = 1
+        var currentRun = 1
+
+        for i in 1..<days.count {
+            let daysBetween = Calendar.current.dateComponents(
+                [.day], from: days[i], to: days[i - 1]
+            ).day ?? 0
+
+            if daysBetween == 1 {
+                currentRun += 1
+                longest = max(longest, currentRun)
+            } else {
+                currentRun = 1
+            }
+        }
+        return longest
+    }
+
+
+    private static func completedDays(from logs: [HabitLog]) -> [Date] {
+        let calendar = Calendar.current
+        let uniqueDays = Set(logs.map { calendar.startOfDay(for: $0.completedAt) })
+        return uniqueDays.sorted(by: >)
+    }
+}

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -38,6 +38,29 @@ final class HabitViewModel: ObservableObject {
                 "HabitViewModel fetchTodayLogs failed: \(logError.localizedDescription)"
             )
         }
+
+        do {
+            let allLogs = try await service.fetchAllLogs(userId: "preview-user")
+            refreshStreaks(from: allLogs)
+        } catch let streakError {
+            print(
+                "HabitViewModel fetchAllLogs failed: \(streakError.localizedDescription)"
+            )
+        }
+    }
+
+    private func refreshStreaks(from logs: [HabitLog]) {
+        habits = habits.map { habit in
+            let habitLogs = logs.filter { $0.habitId == habit.id }
+            var updated = habit
+            updated.currentStreak = StreakCalculator.currentStreak(
+                from: habitLogs
+            )
+            updated.longestStreak = StreakCalculator.longestStreak(
+                from: habitLogs
+            )
+            return updated
+        }
     }
 
     func createHabit(


### PR DESCRIPTION
## 📝 Description
Implements `StreakCalculator` in `Utilities/Helpers/` — a pure utility that calculates `currentStreak` and `longestStreak` from a `[HabitLog]` array. Wires the calculator into `HabitViewModel` via a new `fetchAllLogs` Firestore call so streak values are refreshed every time habits load.

## 🎫 Related Issue
Closes #8

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
N/A — no UI changes in this ticket. Streak values on `Habit` are updated in memory; existing `HabitRowView` already reads `currentStreak`.

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
N/A — no UI changes in this ticket.
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [ ] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [ ] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on iPhone 17 simulator
2. Complete a habit today — tap the checkmark on any row
3. Force-quit and relaunch the app — `currentStreak` on that habit should now show 1
4. To test gap handling: manually insert a `HabitLog` in Firestore with `completedAt` set to 3 days ago (skip yesterday) — relaunch and confirm `currentStreak` resets to 0 while `longestStreak` reflects the historical best

## 💭 Additional Notes
- `fetchAllLogs` is a full-history query ordered newest-first — for users with many logs this could grow. A date-range limit (e.g. last 365 days) is a future optimisation.
- Streak fetch failure is non-blocking: if Firestore returns an error, habits still display with whatever streak values Firestore stored on the document.
- `userId` is still hardcoded as `"preview-user"` — will be replaced when Auth (DD-009) lands.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics