### PR TITLE
feat [DD-009] Added delete habit with cascade log deletion

### DIFF
--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -5,8 +5,9 @@ protocol FirebaseServiceProtocol {
     func fetchHabits(userId: String) async throws -> [Habit]
     func createHabit(_ habit: Habit) async throws
     func habitLogComplition(habitId: String, userId: String) async throws
-     func fetchTodayLogs(userId: String) async throws -> [HabitLog]
+    func fetchTodayLogs(userId: String) async throws -> [HabitLog]
     func fetchAllLogs(userId: String) async throws -> [HabitLog]
+    func deleteHabit(habitId: String, userId: String) async throws
 }
 
 actor FirebaseService: FirebaseServiceProtocol {
@@ -52,21 +53,22 @@ actor FirebaseService: FirebaseServiceProtocol {
         }
         try await ref.setData(data)
     }
-    
-    func fetchTodayLogs (userId: String) async throws -> [HabitLog] {
+
+    func fetchTodayLogs(userId: String) async throws -> [HabitLog] {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: Date())
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
 
-        let snapshot = try await db
+        let snapshot =
+            try await db
             .collection("habitLogs")
             .whereField("userId", isEqualTo: userId)
             .whereField("completedAt", isGreaterThanOrEqualTo: startOfDay)
-            .whereField("completedAt", isLessThan: endOfDay ) // undersök varning innan push
+            .whereField("completedAt", isLessThan: endOfDay)  // undersök varning innan push
             .getDocuments()
 
         return try await MainActor.run {
-            try snapshot.documents.compactMap{
+            try snapshot.documents.compactMap {
                 try $0.data(as: HabitLog.self)
             }
         }
@@ -74,7 +76,8 @@ actor FirebaseService: FirebaseServiceProtocol {
     }
 
     func fetchAllLogs(userId: String) async throws -> [HabitLog] {
-        let snapshot = try await db
+        let snapshot =
+            try await db
             .collection("habitLogs")
             .whereField("userId", isEqualTo: userId)
             .order(by: "completedAt", descending: true)
@@ -85,6 +88,25 @@ actor FirebaseService: FirebaseServiceProtocol {
                 try $0.data(as: HabitLog.self)
             }
         }
+    }
+
+    func deleteHabit(habitId: String, userId: String) async throws {
+
+        let batch = db.batch()
+        let habitRef = db.collection("habits").document(habitId)
+        batch.deleteDocument(habitRef)
+
+        let logsSnapshot =
+            try await db
+            .collection("habitLogs")
+            .whereField("habitId", isEqualTo: habitId)
+            .getDocuments()
+
+        for doc in logsSnapshot.documents {
+            batch.deleteDocument(doc.reference)
+        }
+
+        try await batch.commit()
     }
 
 }

--- a/daily_done/Utilities/Helpers/StreakCalculator.swift
+++ b/daily_done/Utilities/Helpers/StreakCalculator.swift
@@ -13,7 +13,11 @@ enum StreakCalculator {
         for day in days {
             if day == expectedDay {
                 streak += 1
-                expectedDay = Calendar.current.date(byAdding: .day, value: -1, to: expectedDay)!
+                expectedDay = Calendar.current.date(
+                    byAdding: .day,
+                    value: -1,
+                    to: expectedDay
+                )!
             } else {
                 break
             }
@@ -29,9 +33,12 @@ enum StreakCalculator {
         var currentRun = 1
 
         for i in 1..<days.count {
-            let daysBetween = Calendar.current.dateComponents(
-                [.day], from: days[i], to: days[i - 1]
-            ).day ?? 0
+            let daysBetween =
+                Calendar.current.dateComponents(
+                    [.day],
+                    from: days[i],
+                    to: days[i - 1]
+                ).day ?? 0
 
             if daysBetween == 1 {
                 currentRun += 1
@@ -43,10 +50,11 @@ enum StreakCalculator {
         return longest
     }
 
-
     private static func completedDays(from logs: [HabitLog]) -> [Date] {
         let calendar = Calendar.current
-        let uniqueDays = Set(logs.map { calendar.startOfDay(for: $0.completedAt) })
+        let uniqueDays = Set(
+            logs.map { calendar.startOfDay(for: $0.completedAt) }
+        )
         return uniqueDays.sorted(by: >)
     }
 }

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -109,6 +109,26 @@ final class HabitViewModel: ObservableObject {
             )
         }
     }
+
+    func deleteHabit(_ habit: Habit) async {
+        guard let habitId = habit.id else { return }
+
+        habits.removeAll { $0.id == habitId }
+
+        do {
+            try await service.deleteHabit(
+                habitId: habitId,
+                userId: habit.userId
+            )
+        } catch let deleteError {
+            habits.append(habit)
+            error = .deleteFailed(deleteError)
+            print(
+                "HabitViewModel deleteHabit: \(deleteError.localizedDescription)"
+            )
+
+        }
+    }
 }
 
 extension HabitViewModel {
@@ -116,6 +136,7 @@ extension HabitViewModel {
         case loadFailed(Error)
         case nameMissing
         case saveFailed(Error)
+        case deleteFailed(Error)
 
         var errorDescription: String? {
             switch self {
@@ -125,6 +146,8 @@ extension HabitViewModel {
                 return "Please enter a name for the habit."
             case .saveFailed:
                 return "Could not save habit. Please try again."
+            case .deleteFailed:
+                return "Could not delete habit. Please try again."
             }
         }
     }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -47,14 +47,23 @@ struct HabitListView: View {
     }
 
     private var habitList: some View {
-        List(vm.habits) { habit in
-            HabitRowView(
-                habit: habit,
-                isCompleted: vm.completedHabitIds.contains(habit.id ?? ""),
-                onToggle: { Task { await vm.toggleCompletion(for: habit) } }
-            )
-            .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
+        List {
+            ForEach(vm.habits) { habit in
+                HabitRowView(
+                    habit: habit,
+                    isCompleted: vm.completedHabitIds.contains(habit.id ?? ""),
+                    onToggle: { Task { await vm.toggleCompletion(for: habit) } }
+                )
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            }
+            .onDelete { indexSet in
+                for i in indexSet {
+                    let habit = vm.habits[i]
+                    Task { await vm.deleteHabit(habit) }
+                }
+            }
+            
         }
         .listStyle(.plain)
     }


### PR DESCRIPTION
## 📝 Description
Added swipe-to-delete on the habit list that removes the habit document and all associated HabitLog entries from Firestore in a single atomic batch write. The UI updates optimistically and rolls back on failure.

## 🎫 Related Issue
Closes #9

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- Add screenshots after testing on simulator -->

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [ ] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [x] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Launch the app on the simulator and confirm at least one habit exists
2. Swipe left on any habit row — a red Delete button should appear
3. Tap Delete — the row should disappear immediately (optimistic update)
4. Restart the app and verify the deleted habit does not reappear
5. Open Firebase Console → habitLogs collection and confirm no orphaned logs remain for the deleted habitId
6. (Error path) Disable network on simulator, swipe-delete a habit — the habit should reappear and an error alert should show

## 💭 Additional Notes
- Firestore batch write is used so the habit delete and all log deletes are atomic — if the network fails mid-delete, nothing is partially removed
- Optimistic UI: habit is removed from the array before the Firestore call, then rolled back on error — same pattern as `toggleCompletion`
- `deleteFailed` error case added to `HabitError` enum

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [x] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics