### PR TITLE
feat [DD-012] Added StatsViewModel with Daily and Monthly Completions

### DIFF
--- a/daily_done/ViewModels/StatsViewModel.swift
+++ b/daily_done/ViewModels/StatsViewModel.swift
@@ -1,0 +1,67 @@
+import Combine
+import Foundation
+
+struct DayStat: Identifiable {
+    let id: Date
+    let count: Int
+}
+
+@MainActor
+final class StatsViewModel: ObservableObject {
+    @Published var weeklyStats: [DayStat] = []
+    @Published var monthlyStats: [DayStat] = []
+    @Published var isLoading = false
+    @Published var error: StatsError?
+
+    private let service: FirebaseServiceProtocol
+
+    init(service: FirebaseServiceProtocol? = nil) {
+        self.service = service ?? FirebaseService.shared
+    }
+
+    func loadStats(for habitId: String? = nil) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let logs = try await service.fetchAllLogs(userId: "preview-user")
+            let filtered =
+                habitId.map { id in
+                    logs.filter { $0.habitId == id }
+                } ?? logs
+            weeklyStats = completionsPerDay(logs: filtered, days: 7)
+            monthlyStats = completionsPerDay(logs: filtered, days: 30)
+        } catch {
+            self.error = .loadFailed(error)
+            print(
+                "StatsViewModel loadStats failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func completionsPerDay(logs: [HabitLog], days: Int) -> [DayStat] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        return (0..<days).map { offset in
+            let date = calendar.date(byAdding: .day, value: -offset, to: today)!
+            let count = logs.filter {
+                calendar.startOfDay(for: $0.completedAt) == date
+            }.count
+            return DayStat(id: date, count: count)
+        }.reversed()
+    }
+}
+
+extension StatsViewModel {
+    enum StatsError: LocalizedError {
+        case loadFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .loadFailed:
+                return "Could not load statistics. Please try again."
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description
Added `StatsViewModel` that fetches all habit logs and aggregates them into per-day completion counts for the last 7 and 30 days, exposing `@Published` arrays ready to be consumed by SwiftUI Charts in a future ticket.

## 🎫 Related Issue
Closes #12

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
N/A — ViewModel only, no UI in this ticket.

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
N/A — no UI changes in this ticket.
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build the project — confirm it compiles with no errors
2. In `HabitListView` or a preview, instantiate `StatsViewModel()` and call `await vm.loadStats()`
3. Verify `weeklyStats` has 7 entries and `monthlyStats` has 30, each with a `count` ≥ 0
4. Simulate a Firebase error (e.g. disconnect network) and confirm `vm.error` is set with a readable message and the app does not crash

## 💭 Additional Notes
- Uses the existing `fetchAllLogs(userId:)` from `FirebaseService` — no new collections or service changes needed
- `loadStats(for habitId: String? = nil)` — pass `nil` for global stats, pass a habit ID to filter to one habit
- `completionsPerDay` (private) counts matching logs per calendar day and returns them oldest → newest so they map directly onto a chart's x-axis
- `userId` is hardcoded as `"preview-user"` — will be replaced when Firebase Auth is wired up (same pattern as `HabitViewModel`)

## 📊 Impact
- [ ] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [x] Charts/Statistics