### PR TITLE
feat [DD-015] Added Streak History Section to Statistics View

### DIFF
--- a/daily_done/ViewModels/StatsViewModel.swift
+++ b/daily_done/ViewModels/StatsViewModel.swift
@@ -10,6 +10,7 @@ struct DayStat: Identifiable {
 final class StatsViewModel: ObservableObject {
     @Published var weeklyStats: [DayStat] = []
     @Published var monthlyStats: [DayStat] = []
+    @Published var habitStats: [Habit] = []
     @Published var isLoading = false
     @Published var error: StatsError?
 
@@ -24,13 +25,32 @@ final class StatsViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            let logs = try await service.fetchAllLogs(userId: "preview-user")
+            async let fetchedHabits = service.fetchHabits(
+                userId: "preview-user"
+            )
+            async let fetchedLogs = service.fetchAllLogs(userId: "preview-user")
+
+            let (habits, logs) = try await (fetchedHabits, fetchedLogs)
+
             let filtered =
                 habitId.map { id in
                     logs.filter { $0.habitId == id }
                 } ?? logs
             weeklyStats = completionsPerDay(logs: filtered, days: 7)
             monthlyStats = completionsPerDay(logs: filtered, days: 30)
+
+            habitStats = habits.map { habit in
+                let habitLogs = logs.filter { $0.habitId == habit.id }
+                var updated = habit
+                updated.currentStreak = StreakCalculator.currentStreak(
+                    from: habitLogs
+                )
+                updated.longestStreak = StreakCalculator.longestStreak(
+                    from: habitLogs
+                )
+                updated.totalCompletions = habitLogs.count
+                return updated
+            }
         } catch {
             self.error = .loadFailed(error)
             print(

--- a/daily_done/Views/Statistics/StatsView.swift
+++ b/daily_done/Views/Statistics/StatsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct StatsView: View {
-//    @StateObject private var vm = StatsViewModel()
+    //    @StateObject private var vm = StatsViewModel()
     init(service: FirebaseServiceProtocol? = nil) {
         _vm = StateObject(wrappedValue: StatsViewModel(service: service))
     }
@@ -15,14 +15,14 @@ struct StatsView: View {
             }
             .alert(
                 "Error",
-                isPresented: Binding (
+                isPresented: Binding(
                     get: { vm.error != nil },
                     set: { if !$0 { vm.error = nil } }
                 )
             ) {
-                Button ("Retry") { Task { await vm.loadStats() } }
-                Button ("Dismiss", role: .cancel) { vm.error = nil }
-            } message : {
+                Button("Retry") { Task { await vm.loadStats() } }
+                Button("Dismiss", role: .cancel) { vm.error = nil }
+            } message: {
                 Text(vm.error?.errorDescription ?? "")
             }
     }
@@ -46,23 +46,82 @@ struct StatsView: View {
                         .padding(.horizontal, DesignSystem.Spacing.base)
                     WeeklyChartView(stats: vm.weeklyStats)
                         .padding(.horizontal, DesignSystem.Spacing.base)
-                    
+
                     Divider()
-                         .padding(.horizontal, DesignSystem.Spacing.base)
+                        .padding(.horizontal, DesignSystem.Spacing.base)
 
-                    
-                     Text("THIS MONTH")
-                         .font(.caption)
-                         .foregroundStyle(Color("textSecondary"))
-                         .padding(.horizontal, DesignSystem.Spacing.base)
+                    Text("THIS MONTH")
+                        .font(.caption)
+                        .foregroundStyle(Color("textSecondary"))
+                        .padding(.horizontal, DesignSystem.Spacing.base)
 
-                     MonthlyHeatmapView(stats: vm.monthlyStats)
-                         .padding(.horizontal, DesignSystem.Spacing.base)
+                    MonthlyHeatmapView(stats: vm.monthlyStats)
+                        .padding(.horizontal, DesignSystem.Spacing.base)
+
+                    if !vm.habitStats.isEmpty {
+                        Divider()
+                            .padding(.horizontal, DesignSystem.Spacing.base)
+
+                        Text("HABIT STREAKS")
+                            .font(.caption)
+                            .foregroundStyle(Color("textSecondary"))
+                            .padding(.horizontal, DesignSystem.Spacing.base)
+
+                        VStack(spacing: DesignSystem.Spacing.sm) {
+                            ForEach(vm.habitStats) { habit in
+                                HabitStreakRow(habit: habit)
+                                    .padding(
+                                        .horizontal,
+                                        DesignSystem.Spacing.base
+                                    )
+                            }
+                        }
+                    }
                 }
                 .padding(.top, DesignSystem.Spacing.base)
             }
             .background(Color("backgroundPrimary"))
         }
+    }
+}
+
+private struct HabitStreakRow: View {
+    let habit: Habit
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.base) {
+            Circle()
+                .fill(Color(hex: habit.colorHex))
+                .frame(width: 36, height: 36)
+                .overlay(
+                    Image(systemName: habit.iconName)
+                        .foregroundStyle(.white)
+                        .font(.system(size: 16, weight: .medium))
+                )
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxs) {
+                Text(habit.name)
+                    .font(.headline)
+                HStack(spacing: DesignSystem.Spacing.base) {
+                    Label("\(habit.currentStreak)", systemImage: "flame.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                    Text("Best: \(habit.longestStreak)")
+                        .font(.caption)
+                        .foregroundStyle(Color("textSecondary"))
+                    Text("Total: \(habit.totalCompletions)")
+                        .font(.caption)
+                        .foregroundStyle(Color("textSecondary"))
+                }
+            }
+
+            Spacer()
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(
+            Color("neutral-light").opacity(0.5),
+            in: RoundedRectangle(cornerRadius: DesignSystem.Radius.md)
+        )
     }
 }
 
@@ -73,7 +132,34 @@ struct StatsView: View {
 }
 // Mock service that returns fake logs — no Firebase needed
 private struct MockFirebaseService: FirebaseServiceProtocol {
-    func fetchHabits(userId: String) async throws -> [Habit] { [] }
+    func fetchHabits(userId: String) async throws -> [Habit] {
+        [
+            Habit(
+                id: "habit-1",
+                userId: userId,
+                name: "Morning Run",
+                category: .fitness,
+                colorHex: "#FF6B35",
+                iconName: "figure.run",
+                createdAt: Date(),
+                currentStreak: 0,
+                longestStreak: 0,
+                totalCompletions: 0
+            ),
+            Habit(
+                id: "habit-2",
+                userId: userId,
+                name: "Read 20 min",
+                category: .learning,
+                colorHex: "#7B61FF",
+                iconName: "book.fill",
+                createdAt: Date(),
+                currentStreak: 0,
+                longestStreak: 0,
+                totalCompletions: 0
+            ),
+        ]
+    }
     func createHabit(_ habit: Habit) async throws {}
     func habitLogComplition(habitId: String, userId: String) async throws {}
     func fetchTodayLogs(userId: String) async throws -> [HabitLog] { [] }
@@ -84,14 +170,25 @@ private struct MockFirebaseService: FirebaseServiceProtocol {
         let today = calendar.startOfDay(for: Date())
 
         // Simulate 2-3 completions most days this month, gaps on a few days
-        let pattern = [2, 3, 1, 0, 2, 3, 2, 1, 3, 0, 2, 2, 1, 3, 2,
-                       0, 1, 3, 2, 2, 1, 0, 3, 2, 1, 2, 3, 1, 2, 3]
+        let pattern = [
+            2, 3, 1, 0, 2, 3, 2, 1, 3, 0, 2, 2, 1, 3, 2,
+            0, 1, 3, 2, 2, 1, 0, 3, 2, 1, 2, 3, 1, 2, 3,
+        ]
 
         return pattern.enumerated().flatMap { offset, count in
-            let date = calendar.date(byAdding: .day, value: -(29 - offset), to: today)!
+            let date = calendar.date(
+                byAdding: .day,
+                value: -(29 - offset),
+                to: today
+            )!
             return (0..<count).map { _ in
-                HabitLog(id: UUID().uuidString, habitId: "habit-1",
-                         userId: "preview", completedAt: date, location: nil)
+                HabitLog(
+                    id: UUID().uuidString,
+                    habitId: "habit-1",
+                    userId: "preview",
+                    completedAt: date,
+                    location: nil
+                )
             }
         }
     }


### PR DESCRIPTION
## 📝 Description
Added a "Habit Streaks" section to the Statistics screen that displays `currentStreak`, `longestStreak`, and `totalCompletions` per habit. `StatsViewModel` now fetches habits and logs in parallel and computes live streak values using the existing `StreakCalculator`.

## 🎫 Related Issue
Closes #15

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="345" height="732" alt="Skärmavbild 2026-05-05 kl  11 34 32" src="https://github.com/user-attachments/assets/b6304acd-a678-4be4-8c41-6a4b40dfcdef" />

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [x] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Open the app and tap the **Stats** tab
2. Scroll down past the weekly bar chart and monthly heatmap — verify a **"HABIT STREAKS"** section appears
3. Confirm each habit row shows its name, icon, current streak (flame), best streak, and total completions
4. Kill the app, add a habit completion on the Home tab, return to Stats — verify the count updates

## 💭 Additional Notes
- Habits and logs are fetched in parallel using `async let` — no extra network round-trip for the streak data
- `HabitStreakRow` is a private component inside `StatsView.swift` — intentionally not exposed to the module
- Preview mock now returns two habits so the "Stats — with data" Xcode preview shows real streak cards

## 📊 Impact
- [ ] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [x] Charts/Statistics