### PR TITLE
Feature/dd 031 firebase auth service

### DIFF
--- a/daily_done/Models/User.swift
+++ b/daily_done/Models/User.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct User: Identifiable, Codable, Hashable {
+    var id: String
+    var email: String?
+    var displayName: String?
+}

--- a/daily_done/Services/Firebase/FirebaseAuthService.swift
+++ b/daily_done/Services/Firebase/FirebaseAuthService.swift
@@ -1,0 +1,39 @@
+import FirebaseAuth
+import Foundation
+
+protocol FirebaseAuthServiceProtocol {
+    var authStatePublisher: AsyncStream<User?> { get }
+    func signIn(email: String, password: String) async throws
+    func signOut() throws
+}
+
+    actor FirebaseAuthService: FirebaseAuthServiceProtocol {
+
+        nonisolated var authStatePublisher: AsyncStream<User?> {
+            AsyncStream { continuation in
+                let handle = Auth.auth().addStateDidChangeListener {
+                    _,
+                    firebaseUser in
+                    let user = firebaseUser.map {
+                        User(
+                            id: $0.uid,
+                            email: $0.email,
+                            displayName: $0.displayName
+                        )
+                    }
+                    continuation.yield(user)
+                }
+                continuation.onTermination = { _ in
+                    Auth.auth().removeStateDidChangeListener(handle)
+                }
+            }
+        }
+        func signIn(email: String, password: String) async throws {
+            try await Auth.auth().signIn(withEmail: email, password: password)
+        }
+
+        nonisolated func signOut() throws {
+            try Auth.auth().signOut()
+        }
+    }
+

--- a/daily_done/ViewModels/AuthViewModel.swift
+++ b/daily_done/ViewModels/AuthViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+    @Published var isSignedIn: Bool = false
+    @Published var userId: String?
+    @Published var error: AuthError?
+    @Published var isLoading: Bool = true
+
+    private let service: FirebaseAuthServiceProtocol
+    private var listenerTask: Task<Void, Never>?
+
+    init(service: (any FirebaseAuthServiceProtocol)? = nil) {
+        self.service = service ?? FirebaseAuthService()
+        startListening()
+    }
+
+    deinit {
+        listenerTask?.cancel()
+    }
+
+    private func startListening() {
+        listenerTask = Task { [weak self] in
+            guard let self else { return }
+            for await user in service.authStatePublisher {
+                isSignedIn = user != nil
+                userId = user?.id
+                isLoading = false
+            }
+        }
+    }
+
+    func signIn(email: String, password: String) async {
+        error = nil
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await service.signIn(email: email, password: password)
+        } catch {
+            self.error = .signInFailed(error)
+            print("AuthViewModel signIn failed: \(error.localizedDescription)")
+        }
+    }
+
+    func signOut() {
+        error = nil
+        do {
+            try service.signOut()
+        } catch {
+            self.error = .signOutFailed(error)
+            print("AuthViewModel signOut failed: \(error.localizedDescription)")
+        }
+    }
+}
+
+extension AuthViewModel {
+    enum AuthError: LocalizedError {
+        case signInFailed(Error)
+        case signOutFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .signInFailed:
+                return "Could not sign in. Check your email and password."
+            case .signOutFailed:
+                return "Could not sign out. Please try again."
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description
Added the auth service layer for Firebase Auth — a protocol + actor that bridges Firebase's callback-based auth listener to an `AsyncStream`, and an `AuthViewModel` that consumes the stream and publishes sign-in state to the UI.

## 🎫 Related Issue
Closes #49

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
N/A — no UI changes in this ticket. Auth state layer only.

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
N/A — no UI changes in this ticket.
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build the project — confirm no compile errors or warnings
2. Add a breakpoint in `startListening()` — on launch it should fire immediately with the current auth state (signed out = `nil`)
3. Call `signIn(email:password:)` with valid credentials — verify `isSignedIn` becomes `true` and `userId` is populated
4. Call `signOut()` — verify `isSignedIn` becomes `false` and `userId` is `nil`
5. Call `signIn` with invalid credentials — verify `error` is set to `.signInFailed` and `isLoading` resets to `false`

## 💭 Additional Notes
- `AuthViewModel` is not yet wired into `daily_doneApp.swift` — that happens in the sign-in screen ticket (DD-032/DD-033)
- `HabitViewModel` still uses `"preview-user"` as a hardcoded userId — will be replaced with `AuthViewModel.userId` once the session guard is in place
- `FirebaseAuthService` has no `static let shared` — injected via init to keep it testable

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics