### PR TITLE
feat [DD-032] Added SignInView with email/password fields and loading…

### DIFF
--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+struct SignInView: View {
+
+    @ObservedObject var viewModel: AuthViewModel
+
+    @State private var email = ""
+    @State private var password = ""
+
+   
+    @FocusState private var focusedField: Field?
+
+    private enum Field { case email, password }
+
+    var body: some View {
+        ZStack {
+            Color("backgroundPrimary")
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+                logoSection
+                Spacer().frame(height: 40)
+
+                VStack(spacing: 12) {
+                    emailField
+                    passwordField
+                    forgotPasswordLink
+                }
+                .padding(.horizontal, 32)
+
+                Spacer().frame(height: 32)
+                signInButton
+                    .padding(.horizontal, 32)
+                Spacer()
+                signUpFooter
+                    .padding(.bottom, 32)
+            }
+        }
+        
+        .alert(
+            "Sign In Failed",
+            isPresented: Binding(
+                get: { viewModel.error != nil },
+                set: { if !$0 { viewModel.error = nil } }
+            )
+        ) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            Text(viewModel.error?.localizedDescription ?? "")
+        }
+    }
+
+
+    private var logoSection: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(Color("brandPrimary").opacity(0.2))
+                    .frame(width: 80, height: 80)
+                Circle()
+                    .fill(Color("brandPrimary").opacity(0.55))
+                    .frame(width: 60, height: 60)
+                Image(systemName: "timer")
+                    .font(.system(size: 26, weight: .medium))
+                    .foregroundStyle(.white)
+            }
+            VStack(spacing: 8) {
+                Text("Welcome back")
+                    .font(.title2).fontWeight(.bold)
+                    .foregroundStyle(Color("textPrimary"))
+                Text("Sign in to continue")
+                    .font(.body)
+                    .foregroundStyle(Color("textSecondary"))
+            }
+        }
+    }
+
+    private var emailField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "envelope")
+                .foregroundStyle(Color("textSecondary"))
+                .frame(width: 20)
+            TextField("Email address", text: $email)
+                .keyboardType(.emailAddress)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .focused($focusedField, equals: .email)
+                .foregroundStyle(Color("textPrimary"))
+                .submitLabel(.next)
+                .onSubmit { focusedField = .password }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 16)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+
+    private var passwordField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "lock")
+                .foregroundStyle(Color("textSecondary"))
+                .frame(width: 20)
+            SecureField("Password", text: $password)
+                .focused($focusedField, equals: .password)
+                .foregroundStyle(Color("textPrimary"))
+                .submitLabel(.done)
+                .onSubmit { Task { await signIn() } }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 16)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var forgotPasswordLink: some View {
+        HStack {
+            Spacer()
+            Button("Forgot password?") { }
+                // TODO: implement forgot password flow later ticket
+                .font(.caption)
+                .foregroundStyle(Color("brandPrimary"))
+        }
+    }
+
+  
+    private var signInButton: some View {
+        Button {
+           
+            Task { await signIn() }
+        } label: {
+            HStack(spacing: 8) {
+                if viewModel.isLoading {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Sign In").fontWeight(.semibold)
+                    Image(systemName: "arrow.right")
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                LinearGradient(
+                    colors: [Color("brandPrimary"), Color("brandAccent")],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+
+            .opacity(email.isEmpty || password.isEmpty ? 0.6 : 1.0)
+        }
+
+        .disabled(viewModel.isLoading || email.isEmpty || password.isEmpty)
+    }
+
+    private var signUpFooter: some View {
+        HStack(spacing: 4) {
+            Text("Don't have an account?")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            Button("Sign Up") { }
+                // TODO: navigate to sign-up screen
+                .font(.caption)
+                .foregroundStyle(Color("brandPrimary"))
+        }
+    }
+
+    private func signIn() async {
+        focusedField = nil
+        await viewModel.signIn(email: email, password: password)
+    }
+}
+
+#Preview {
+    SignInView(viewModel: AuthViewModel())
+        .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## 📝 Description
Built the sign-in screen (`Views/Auth/SignInView.swift`) with email and password fields, a gradient sign-in button, loading state, and error alert. The view is stateless — all auth logic delegates to `AuthViewModel` via `@ObservedObject`.

## 🎫 Related Issue
Closes #50

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="358" height="737" alt="Skärmavbild 2026-05-05 kl  16 58 52" src="https://github.com/user-attachments/assets/65fe79d9-e572-44a0-90bf-ed1ec32a58e3" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [x] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Wire `SignInView(viewModel:)` into `daily_doneApp` temporarily so it appears on launch
2. Leave both fields empty — verify the Sign In button is dimmed and non-tappable
3. Enter a valid email and password — verify button becomes fully opaque and tappable
4. Tap Sign In — verify spinner appears inside the button while the request is in progress
5. Enter wrong credentials — verify the "Sign In Failed" alert appears with an error message
6. Tap OK to dismiss alert — verify it clears and the form is ready again
7. Tap "Forgot password?" and "Sign Up" — verify they are visible but take no action (stubs)

## 💭 Additional Notes
- "Forgot password?" and "Sign Up" links are stubbed with `// TODO` — routing is handled in DD-034 (session guard) and a future sign-up ticket
- `@FocusState` moves keyboard focus from email → password on Return, and dismisses keyboard on form submit
- `LinearGradient` uses `Color("brandPrimary")` and `Color("brandAccent")` from Assets — no hardcoded hex values

## 📊 Impact
- [ ] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics