### PR TITLE
feat [DD-033] Added ProfileView with user info, stats, settings, and sign-out

### DIFF
--- a/daily_done/ViewModels/AuthViewModel.swift
+++ b/daily_done/ViewModels/AuthViewModel.swift
@@ -5,6 +5,8 @@ import Combine
 final class AuthViewModel: ObservableObject {
     @Published var isSignedIn: Bool = false
     @Published var userId: String?
+    @Published var email: String?
+    @Published var displayName: String?
     @Published var error: AuthError?
     @Published var isLoading: Bool = true
 
@@ -26,6 +28,8 @@ final class AuthViewModel: ObservableObject {
             for await user in service.authStatePublisher {
                 isSignedIn = user != nil
                 userId = user?.id
+                email = user?.email
+                displayName = user?.displayName
                 isLoading = false
             }
         }

--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SignInView: View {
 
-    @ObservedObject var viewModel: AuthViewModel
+    @ObservedObject var vm: AuthViewModel
 
     @State private var email = ""
     @State private var password = ""
@@ -41,13 +41,13 @@ struct SignInView: View {
         .alert(
             "Sign In Failed",
             isPresented: Binding(
-                get: { viewModel.error != nil },
-                set: { if !$0 { viewModel.error = nil } }
+                get: { vm.error != nil },
+                set: { if !$0 { vm.error = nil } }
             )
         ) {
-            Button("OK") { viewModel.error = nil }
+            Button("OK") { vm.error = nil }
         } message: {
-            Text(viewModel.error?.localizedDescription ?? "")
+            Text(vm.error?.localizedDescription ?? "")
         }
     }
 
@@ -129,7 +129,7 @@ struct SignInView: View {
             Task { await signIn() }
         } label: {
             HStack(spacing: 8) {
-                if viewModel.isLoading {
+                if vm.isLoading {
                     ProgressView().tint(.white)
                 } else {
                     Text("Sign In").fontWeight(.semibold)
@@ -151,7 +151,7 @@ struct SignInView: View {
             .opacity(email.isEmpty || password.isEmpty ? 0.6 : 1.0)
         }
 
-        .disabled(viewModel.isLoading || email.isEmpty || password.isEmpty)
+        .disabled(vm.isLoading || email.isEmpty || password.isEmpty)
     }
 
     private var signUpFooter: some View {
@@ -168,11 +168,11 @@ struct SignInView: View {
 
     private func signIn() async {
         focusedField = nil
-        await viewModel.signIn(email: email, password: password)
+        await vm.signIn(email: email, password: password)
     }
 }
 
 #Preview {
-    SignInView(viewModel: AuthViewModel())
+    SignInView(vm: AuthViewModel())
         .preferredColorScheme(.dark)
 }

--- a/daily_done/Views/ContentView.swift
+++ b/daily_done/Views/ContentView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct ContentView: View {
+
+    @ObservedObject var authViewModel: AuthViewModel
+
     var body: some View {
         TabView {
             NavigationStack {
@@ -9,17 +12,16 @@ struct ContentView: View {
             .tabItem {
                 Label("Habits", systemImage: "checkmark.circle")
             }
-            
-            NavigationStack{
+
+            NavigationStack {
                 StatsView()
             }
             .tabItem {
                 Label("Stats", systemImage: "chart.bar")
             }
-            
+
             NavigationStack {
-                Text("Profile View Coming Soon")
-                    .navigationTitle(Text("Settings"))
+                ProfileView(vm: authViewModel)
             }
             .tabItem {
                 Label("Profile", systemImage: "person.circle")
@@ -29,5 +31,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    ContentView(authViewModel: AuthViewModel())
 }

--- a/daily_done/Views/Profile/ProfileView.swift
+++ b/daily_done/Views/Profile/ProfileView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+struct ProfileView: View {
+
+    @ObservedObject var vm: AuthViewModel
+
+    @AppStorage("notificationsEnabled") private var notificationsEnabled = true
+    @AppStorage("darkModeEnabled") private var darkModeEnabled = true
+    @AppStorage("locationEnabled") private var locationEnabled = false
+
+    var body: some View {
+        ZStack {
+            Color("backgroundPrimary")
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: DesignSystem.Spacing.lg) {
+                    avatarSection
+                        .padding(.top, DesignSystem.Spacing.xl)
+                    statsSection
+                    settingsSection
+                    signOutButton
+                        .padding(.horizontal, DesignSystem.Spacing.base)
+                        .padding(.bottom, DesignSystem.Spacing.xxl)
+                }
+            }
+        }
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    // TODO: open settings sheet (future ticket)
+                } label: {
+                    Image(systemName: "gearshape")
+                        .foregroundStyle(Color("textSecondary"))
+                }
+                .accessibilityLabel("Settings")
+            }
+        }
+        .alert(
+            "Sign Out Failed",
+            isPresented: Binding(
+                get: { vm.error != nil },
+                set: { if !$0 { vm.error = nil } }
+            )
+        ) {
+            Button("OK") { vm.error = nil }
+        } message: {
+            Text(vm.error?.localizedDescription ?? "")
+        }
+    }
+
+
+    private var avatarSection: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            ZStack {
+                Circle()
+                    .fill(Color("brandPrimary").opacity(0.6))
+                    .frame(width: 80, height: 80)
+                Text(initials)
+                    .font(.title2).fontWeight(.bold)
+                    .foregroundStyle(.white)
+            }
+            .accessibilityHidden(true)
+
+            VStack(spacing: DesignSystem.Spacing.xxs) {
+                Text(vm.displayName ?? "User")
+                    .font(.title3).fontWeight(.bold)
+                    .foregroundStyle(Color("textPrimary"))
+                Text(vm.email ?? "")
+                    .font(.subheadline)
+                    .foregroundStyle(Color("textSecondary"))
+                    .accessibilityLabel("Email: \(vm.email ?? "Unknown")")
+            }
+        }
+    }
+
+
+    private var statsSection: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            // TODO: replace with real counts from HabitViewModel
+            StatCard(value: "0", label: "Habits", color: Color("brandPrimary"))
+            StatCard(value: "0", label: "Done", color: Color("brandPrimary"))
+            StatCard(value: "0", label: "Best streak", color: Color("brandAccent"))
+        }
+        .padding(.horizontal, DesignSystem.Spacing.base)
+    }
+
+
+    private var settingsSection: some View {
+        VStack(spacing: 0) {
+            SettingsRow(icon: "bell", label: "Notifications", isOn: $notificationsEnabled)
+            Divider().padding(.leading, 52)
+            SettingsRow(icon: "moon", label: "Dark Mode", isOn: $darkModeEnabled)
+            Divider().padding(.leading, 52)
+            SettingsRow(icon: "location", label: "Location Tracking", isOn: $locationEnabled)
+        }
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.lg))
+        .padding(.horizontal, DesignSystem.Spacing.base)
+    }
+
+
+    private var signOutButton: some View {
+        Button {
+            vm.signOut()
+        } label: {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                Text("Sign Out").fontWeight(.semibold)
+            }
+            .foregroundStyle(Color("brandAccent"))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DesignSystem.Spacing.base)
+            .background(Color("brandAccent").opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Radius.md)
+                    .stroke(Color("brandAccent").opacity(0.4), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel("Sign out of your account")
+    }
+
+
+    private var initials: String {
+        if let name = vm.displayName, !name.isEmpty {
+            let parts = name.split(separator: " ")
+            let first = parts.first?.prefix(1) ?? ""
+            let last = parts.dropFirst().first?.prefix(1) ?? ""
+            return "\(first)\(last)".uppercased()
+        }
+        let username = vm.email?.split(separator: "@").first ?? ""
+        return String(username.prefix(2)).uppercased()
+    }
+}
+
+
+private struct StatCard: View {
+    let value: String
+    let label: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: DesignSystem.Spacing.xxs) {
+            Text(value)
+                .font(.title2).fontWeight(.bold)
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DesignSystem.Spacing.base)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.md))
+    }
+}
+
+private struct SettingsRow: View {
+    let icon: String
+    let label: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: icon)
+                .frame(width: 20)
+                .foregroundStyle(Color("brandPrimary"))
+            Text(label)
+                .foregroundStyle(Color("textPrimary"))
+            Spacer()
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+                .tint(Color("brandPrimary"))
+        }
+        .padding(.horizontal, DesignSystem.Spacing.base)
+        .padding(.vertical, 14)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfileView(vm: AuthViewModel())
+    }
+    .preferredColorScheme(.dark)
+}

--- a/daily_done/daily_doneApp.swift
+++ b/daily_done/daily_doneApp.swift
@@ -14,9 +14,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct daily_doneApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    @StateObject private var authViewModel = AuthViewModel()
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(authViewModel: authViewModel)
         }
     }
 }


### PR DESCRIPTION
## 📝 Description
Created ProfileView for the Profile tab, replacing the placeholder in ContentView. The view displays the signed-in user's avatar initials, display name, email, stat cards, and settings toggles, with a sign-out button that calls `AuthViewModel.signOut()`. AuthViewModel was extended with `email` and `displayName` properties captured from the auth state stream.

## 🎫 Related Issue
Closes #51

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactoring

## 📱 Screenshots/Videos

<img width="441" height="910" alt="Skärmavbild 2026-05-05 kl  20 17 21" src="https://github.com/user-attachments/assets/08af1fa8-e332-4597-a833-e5161994943d" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [ ] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [x] Accessibility labels added (if relevant)
- [x] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on the iPhone 17 simulator
2. Sign in with a Firebase test account — the Profile tab should show your initials in the avatar circle and your email below your name
3. Tap each settings toggle (Notifications, Dark Mode, Location) — they should persist after closing and reopening the app
4. Tap **Sign Out** — the button calls `signOut()` on AuthViewModel; routing back to SignInView is handled in DD-034
5. Disconnect from the network and tap Sign Out — verify the "Sign Out Failed" error alert appears

## 💭 Additional Notes
- Stat cards (Habits, Done, Best Streak) show `0` as placeholder values — real data wired in a future ticket when HabitViewModel is passed into ProfileView
- Settings toggles use `@AppStorage` for persistence; actual wiring to NotificationService (DD-016), LocationService (DD-018), and dark mode (DD-020) tracked in TODO_REVIEW.md
- Firebase Security Rules not yet updated — tracked in TODO_REVIEW.md, scheduled after EPIC-4 is fully merged

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics