### PR TITLE
feat [DD-034] Added Session Guard and Wired Real userId Through App

### DIFF
--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -9,8 +9,10 @@ final class HabitViewModel: ObservableObject {
     @Published var completedHabitIds: Set<String> = []
 
     private let service: FirebaseServiceProtocol
+    private let userId: String
 
-    init(service: FirebaseServiceProtocol? = nil) {
+    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+        self.userId = userId
         self.service = service ?? FirebaseService.shared
     }
 
@@ -19,7 +21,7 @@ final class HabitViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            habits = try await service.fetchHabits(userId: "preview-user")
+            habits = try await service.fetchHabits(userId: userId)
         } catch let fetchError {
             error = .loadFailed(fetchError)
             print(
@@ -30,7 +32,7 @@ final class HabitViewModel: ObservableObject {
 
         do {
             let todayLogs = try await service.fetchTodayLogs(
-                userId: "preview-user"
+                userId: userId
             )
             completedHabitIds = Set(todayLogs.compactMap { $0.habitId })
         } catch let logError {
@@ -40,7 +42,7 @@ final class HabitViewModel: ObservableObject {
         }
 
         do {
-            let allLogs = try await service.fetchAllLogs(userId: "preview-user")
+            let allLogs = try await service.fetchAllLogs(userId: userId)
             refreshStreaks(from: allLogs)
         } catch let streakError {
             print(
@@ -76,7 +78,7 @@ final class HabitViewModel: ObservableObject {
         }
 
         let habit = Habit(
-            userId: "preview-user",  // Todo: updateras Auth () id senare
+            userId: userId,
             name: trimmedName,
             category: category,
             colorHex: colorHex,

--- a/daily_done/ViewModels/StatsViewModel.swift
+++ b/daily_done/ViewModels/StatsViewModel.swift
@@ -15,8 +15,10 @@ final class StatsViewModel: ObservableObject {
     @Published var error: StatsError?
 
     private let service: FirebaseServiceProtocol
+    private let userId: String
 
-    init(service: FirebaseServiceProtocol? = nil) {
+    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+        self.userId = userId
         self.service = service ?? FirebaseService.shared
     }
 
@@ -25,10 +27,8 @@ final class StatsViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            async let fetchedHabits = service.fetchHabits(
-                userId: "preview-user"
-            )
-            async let fetchedLogs = service.fetchAllLogs(userId: "preview-user")
+            async let fetchedHabits = service.fetchHabits(userId: userId)
+            async let fetchedLogs = service.fetchAllLogs(userId: userId)
 
             let (habits, logs) = try await (fetchedHabits, fetchedLogs)
 

--- a/daily_done/Views/ContentView.swift
+++ b/daily_done/Views/ContentView.swift
@@ -1,27 +1,26 @@
 import SwiftUI
 
 struct ContentView: View {
-
-    @ObservedObject var authViewModel: AuthViewModel
-
+    let userId: String
+    @ObservedObject var auth: AuthViewModel
     var body: some View {
         TabView {
             NavigationStack {
-                HabitListView()
+                HabitListView(userId: userId)
             }
             .tabItem {
                 Label("Habits", systemImage: "checkmark.circle")
             }
 
             NavigationStack {
-                StatsView()
+                StatsView(userId: userId)
             }
             .tabItem {
                 Label("Stats", systemImage: "chart.bar")
             }
 
             NavigationStack {
-                ProfileView(vm: authViewModel)
+                ProfileView(vm: auth)
             }
             .tabItem {
                 Label("Profile", systemImage: "person.circle")
@@ -31,5 +30,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(authViewModel: AuthViewModel())
+    ContentView(userId: "preview-user", auth: AuthViewModel())
 }

--- a/daily_done/Views/Habits/CreateHabitSheet.swift
+++ b/daily_done/Views/Habits/CreateHabitSheet.swift
@@ -198,5 +198,5 @@ struct CreateHabitSheet: View {
     }
 }
 #Preview {
-    CreateHabitSheet(vm: HabitViewModel())
+    CreateHabitSheet(vm: HabitViewModel(userId: "preview-user"))
 }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -86,7 +86,7 @@ struct HabitListView: View {
 
 #Preview {
     NavigationStack {
-        HabitListView()
+        HabitListView(userId: "preview-user")
 
     }
 }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
 
 struct HabitListView: View {
-    @StateObject private var vm = HabitViewModel()
-    @State private var showCreateSheet = false
+    @StateObject private var vm: HabitViewModel
+      @State private var showCreateSheet = false
+
+      init(userId: String) {
+          _vm = StateObject(wrappedValue: HabitViewModel(userId: userId))
+      }
 
     var body: some View {
         contentView

--- a/daily_done/Views/Statistics/StatsView.swift
+++ b/daily_done/Views/Statistics/StatsView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
 struct StatsView: View {
-    //    @StateObject private var vm = StatsViewModel()
-    init(service: FirebaseServiceProtocol? = nil) {
-        _vm = StateObject(wrappedValue: StatsViewModel(service: service))
+
+    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+        _vm = StateObject(
+            wrappedValue: StatsViewModel(userId: userId, service: service)
+        )
     }
     @StateObject private var vm: StatsViewModel
 
@@ -127,7 +129,7 @@ private struct HabitStreakRow: View {
 
 #Preview {
     NavigationStack {
-        StatsView()
+        StatsView(userId: "preview-user")
     }
 }
 // Mock service that returns fake logs — no Firebase needed
@@ -196,6 +198,6 @@ private struct MockFirebaseService: FirebaseServiceProtocol {
 
 #Preview("Stats — with data") {
     NavigationStack {
-        StatsView(service: MockFirebaseService())
+        StatsView(userId: "preview-user", service: MockFirebaseService())
     }
 }

--- a/daily_done/daily_doneApp.swift
+++ b/daily_done/daily_doneApp.swift
@@ -14,10 +14,19 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct daily_doneApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    @StateObject private var authViewModel = AuthViewModel()
+    @StateObject private var auth = AuthViewModel()
+    
     var body: some Scene {
         WindowGroup {
-            ContentView(authViewModel: authViewModel)
+            if auth.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if auth.isSignedIn, let userId = auth.userId {
+                ContentView(userId: userId, auth: auth)
+                
+            } else {
+                SignInView(vm: auth)
+            }
         }
     }
 }


### PR DESCRIPTION
## 📝 Description
Wired `AuthViewModel` into the app root so the app routes to `SignInView` when unauthenticated and `ContentView` when signed in. Replaced all hardcoded `"preview-user"` strings with the real Firebase Auth UID flowing as a plain `String` parameter through `ContentView` → `HabitListView`/`StatsView` → their ViewModels.

## 🎫 Related Issue
Closes #52

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- No new UI — routing logic only. No screenshots needed. -->


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [ ] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [ ] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Run the app on the simulator — it should show `SignInView` (not the tab view) since no user is signed in
2. Sign in with a valid Firebase test account — app should navigate to `ContentView` showing Habits, Stats, and Profile tabs
3. Check that habits and stats load correctly (data comes from the signed-in user's UID, not "preview-user")
4. Sign out from the Profile tab — app should return to `SignInView`
5. Force-quit and relaunch — app should show a brief spinner, then route directly to `ContentView` if the session persisted

## 💭 Additional Notes
`userId` flows as a plain `String` parameter — no `@EnvironmentObject`, no singleton. Views that need a ViewModel with a dynamic init param use the `StateObject(wrappedValue:)` pattern. `daily_doneApp` shows a `ProgressView` while Firebase resolves the persisted auth session on launch to prevent a flash of `SignInView` for already-signed-in users.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics