### PR TITLE
feat [DD-035] Added SplashView landing screen before sign-in

### DIFF
--- a/daily_done/Views/Auth/SplashView.swift
+++ b/daily_done/Views/Auth/SplashView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct SplashView: View {
+    var onGetStarted: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color("backgroundPrimary")
+                .ignoresSafeArea()
+
+            RadialGradient(
+                colors: [Color("brandPrimary").opacity(0.3), .clear],
+                center: .center,
+                startRadius: 0,
+                endRadius: 280
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                ZStack {
+                    Circle()
+                        .fill(Color("brandPrimary").opacity(0.9))
+                        .frame(width: 96, height: 96)
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 40, weight: .medium))
+                        .foregroundStyle(.white)
+                }
+
+                Spacer().frame(height: 32)
+
+                VStack(spacing: 12) {
+                    Text("Daily Done")
+                        .font(.largeTitle).fontWeight(.bold)
+                        .foregroundStyle(Color("textPrimary"))
+                    Text("Build habits that stick")
+                        .font(.body)
+                        .foregroundStyle(Color("textSecondary"))
+                }
+
+                Spacer().frame(height: 48)
+
+                Button(action: onGetStarted) {
+                    HStack(spacing: 8) {
+                        Text("Get Started").fontWeight(.semibold)
+                        Image(systemName: "arrow.right")
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color("brandPrimary"))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.horizontal, 32)
+
+                Spacer()
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Text("v1.0.0")
+                        .font(.caption2)
+                        .foregroundStyle(Color("textSecondary").opacity(0.5))
+                        .padding(.leading, 16)
+                        .padding(.bottom, 16)
+                    Spacer()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashView(onGetStarted: {})
+        .preferredColorScheme(.dark)
+}

--- a/daily_done/daily_doneApp.swift
+++ b/daily_done/daily_doneApp.swift
@@ -15,7 +15,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct daily_doneApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @StateObject private var auth = AuthViewModel()
-    
+    @State private var splashDissmised = false
+
     var body: some Scene {
         WindowGroup {
             if auth.isLoading {
@@ -23,7 +24,9 @@ struct daily_doneApp: App {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if auth.isSignedIn, let userId = auth.userId {
                 ContentView(userId: userId, auth: auth)
-                
+
+            } else if !splashDissmised {
+                SplashView(onGetStarted: { splashDissmised = true })
             } else {
                 SignInView(vm: auth)
             }


### PR DESCRIPTION
## 📝 Description
Added a dedicated SplashView shown on cold launch before the user reaches the sign-in screen. The view displays the flame icon, app name, tagline, and a "Get Started" button — navigation to SignInView is handled by the app routing layer, keeping the view purely presentational.

## 🎫 Related Issue
Closes #54

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="441" height="910" alt="Skärmavbild 2026-05-06 kl  07 25 18" src="https://github.com/user-attachments/assets/0c9b7632-192a-4f11-a799-c251f9b29691" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [x] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [x] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Cold launch the app on the simulator — SplashView should appear with flame icon, "Daily Done", and "Build habits that stick"
2. Tap "Get Started" — should navigate to SignInView with no errors
3. Sign in with valid credentials — should proceed to ContentView as normal
4. Sign out, then tap "Get Started" again in the same session — splash should not reappear (already dismissed)
5. Kill the app and cold launch again — splash should appear again

## 💭 Additional Notes
- `splashDismissed` is `@State` on the `App` struct — resets on every cold launch, persists for the session. Returning users with an active Firebase session skip the splash entirely (routing hits `isSignedIn` branch first).
- Dark mode is inherited from `backgroundPrimary` and named color tokens — no hardcoded hex values.

## 📊 Impact
- [ ] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics