### PR TITLE
feat [DD-017] Added Local Push Notification Delivery and Permission Request

### DIFF
--- a/daily_done/Services/Notifications/NotificationService.swift
+++ b/daily_done/Services/Notifications/NotificationService.swift
@@ -1,9 +1,23 @@
 import Foundation
 import UserNotifications
 
-final class NotificationService {
+protocol NotificationServiceProtocol {
+    func requestPermission() async -> Bool
+    func scheduleReminder(for habit: Habit) async
+    func cancelReminder(habitId: String)
+}
+
+final class NotificationService: NotificationServiceProtocol {
     static let shared = NotificationService()
     private init() {}
+
+    private static let motivationalPhrases = [
+        "Keep the streak alive!",
+        "Small steps, big results.",
+        "You've got this — one habit at a time.",
+        "Consistency is the key to success.",
+        "Time to build something great today.",
+    ]
 
     func requestPermission() async -> Bool {
         do {
@@ -17,15 +31,15 @@ final class NotificationService {
         }
     }
 
-    func scheduleReminder(for habit: Habit) {
+    func scheduleReminder(for habit: Habit) async {
         guard habit.isReminderEnabled,
             let reminderTime = habit.reminderTime,
             let habitId = habit.id
         else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "Daily Done"
-        content.body = "Time for your habit: \(habit.name)"
+        content.title = habit.name
+        content.body = Self.motivationalPhrases.randomElement() ?? "Time for your habit!"
         content.sound = .default
 
         let components = Calendar.current.dateComponents(
@@ -43,6 +57,13 @@ final class NotificationService {
             content: content,
             trigger: trigger
         )
+        
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        }catch {
+            print("Failed to schedule notification for \(habit.name): \(error.localizedDescription)")
+
+        }
     }
 
     func cancelReminder(habitId: String) {

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -8,12 +8,18 @@ final class HabitViewModel: ObservableObject {
     @Published var error: HabitError?
     @Published var completedHabitIds: Set<String> = []
 
-    private let service: FirebaseServiceProtocol
     private let userId: String
+    private let service: FirebaseServiceProtocol
+    private let notificationService: NotificationServiceProtocol
 
-    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+    init(
+        userId: String,
+        service: FirebaseServiceProtocol? = nil,
+        notificationService: NotificationServiceProtocol? = nil
+    ) {
         self.userId = userId
         self.service = service ?? FirebaseService.shared
+        self.notificationService = notificationService ?? NotificationService.shared
     }
 
     func loadHabits() async {
@@ -122,6 +128,10 @@ final class HabitViewModel: ObservableObject {
         guard let habitId = habit.id else { return }
 
         habits.removeAll { $0.id == habitId }
+
+        if habit.isReminderEnabled {
+            notificationService.cancelReminder(habitId: habitId)
+        }
 
         do {
             try await service.deleteHabit(

--- a/daily_done/ViewModels/NotificationViewModel.swift
+++ b/daily_done/ViewModels/NotificationViewModel.swift
@@ -5,9 +5,9 @@ import Combine
 final class NotificationViewModel: ObservableObject {
     @Published var permissionDenied = false
     
-    private let service: NotificationService
-    
-    init (service: NotificationService? = nil ) {
+    private let service: NotificationServiceProtocol
+
+    init(service: NotificationServiceProtocol? = nil) {
         self.service = service ?? NotificationService.shared
     }
     
@@ -17,8 +17,8 @@ final class NotificationViewModel: ObservableObject {
         return granted
     }
     
-    func scheduleIfEnabled(for habit: Habit) {
-          service.scheduleReminder(for: habit)
+    func scheduleIfEnabled(for habit: Habit) async {
+          await service.scheduleReminder(for: habit)
       }
 
       func cancelReminder(habitId: String) {

--- a/daily_done/Views/Habits/CreateHabitSheet.swift
+++ b/daily_done/Views/Habits/CreateHabitSheet.swift
@@ -219,7 +219,7 @@ struct CreateHabitSheet: View {
                 isReminderEnabled: reminderEnabled,
                 reminderTime: reminderEnabled ? reminderTime : nil
             )
-            notificationVM.scheduleIfEnabled(for: saved)
+            await notificationVM.scheduleIfEnabled(for: saved)
             dismiss()
 
         } catch HabitViewModel.HabitError.nameMissing {


### PR DESCRIPTION
## 📝 Description
Wired up local push notification delivery so habits with reminders actually schedule a repeating `UNCalendarNotificationTrigger`. Also extracted `NotificationServiceProtocol` to match the architecture pattern established by `FirebaseServiceProtocol`, making the notification layer fully testable.

## 🎫 Related Issue
Closes #17

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="434" height="902" alt="Skärmavbild 2026-05-06 kl  14 04 12" src="https://github.com/user-attachments/assets/34828635-d8ef-442e-bd75-f0d3e85a98de" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [ ] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary) — no new collections, no rule changes needed
- [x] No hardcoded API keys
- [x] Error handling for network failures exists — all async calls wrapped in do/catch

### UI/UX
N/A — no UI changes in this ticket. Reminder toggle and time picker were built in DD-016.

### Git
- [ ] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [ ] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on simulator — tap `+` to create a new habit
2. Toggle the Reminder switch on — iOS permission dialog should appear
3. Grant permission, pick a time 1–2 minutes from now, tap Save
4. Lock the simulator and wait — notification should arrive at the chosen time with the habit name as title and a motivational phrase as body
5. Swipe to delete that habit — verify no further notifications arrive at the scheduled time (check via Settings → Notifications → Daily Done)
6. Deny permission on a second habit — verify the toggle resets to off and the error message appears

## 💭 Additional Notes
- **Critical bug fixed:** `scheduleReminder` in DD-016 built a `UNNotificationRequest` but never called `UNUserNotificationCenter.current().add(request)` — notifications were silently discarded on every save.
- **Architecture:** Added `NotificationServiceProtocol` following the same pattern as `FirebaseServiceProtocol`. Both `NotificationViewModel` and `HabitViewModel` now hold the protocol type, making the notification layer injectable and testable via mocks.
- **Cancel on delete:** `HabitViewModel.deleteHabit` now calls `cancelReminder` before removing the Firestore document, so deleted habits stop firing.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [x] Notifications
- [ ] Location services
- [ ] Charts/Statistics