### PR TITLE
feat [DD-018] Added GPS coordinate logging on habit completion

### DIFF
--- a/daily_done.xcodeproj/project.pbxproj
+++ b/daily_done.xcodeproj/project.pbxproj
@@ -16,9 +16,22 @@
 		270BF9C12F9FED4900850F6F /* daily_done.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = daily_done.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		27CB5B982FAB730900A1D2D9 /* Exceptions for "daily_done" folder in "daily_done" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"daily-done-Info.plist",
+			);
+			target = 270BF9C02F9FED4900850F6F /* daily_done */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		270BF9C32F9FED4900850F6F /* daily_done */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				27CB5B982FAB730900A1D2D9 /* Exceptions for "daily_done" folder in "daily_done" target */,
+			);
 			path = daily_done;
 			sourceTree = "<group>";
 		};
@@ -268,6 +281,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "daily-done-Info.plist";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Daily Done logs where you completed your habit.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -299,6 +314,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "daily-done-Info.plist";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Daily Done logs where you completed your habit.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -4,7 +4,11 @@ import Foundation
 protocol FirebaseServiceProtocol {
     func fetchHabits(userId: String) async throws -> [Habit]
     func createHabit(_ habit: Habit) async throws -> String
-    func habitLogComplition(habitId: String, userId: String) async throws
+    func habitLogComplition(
+        habitId: String,
+        userId: String,
+        location: HabitLocation?
+    ) async throws
     func fetchTodayLogs(userId: String) async throws -> [HabitLog]
     func fetchAllLogs(userId: String) async throws -> [HabitLog]
     func deleteHabit(habitId: String, userId: String) async throws
@@ -39,14 +43,18 @@ actor FirebaseService: FirebaseServiceProtocol {
         return ref.documentID
     }
 
-    func habitLogComplition(habitId: String, userId: String) async throws {
+    func habitLogComplition(
+        habitId: String,
+        userId: String,
+        location: HabitLocation?
+    ) async throws {
 
         let log = HabitLog(
             id: UUID().uuidString,
             habitId: habitId,
             userId: userId,
             completedAt: Date(),
-            location: nil
+            location: location
         )
         let ref = db.collection("habitLogs").document()
         let data = try await MainActor.run {

--- a/daily_done/Services/Location/LocationService.swift
+++ b/daily_done/Services/Location/LocationService.swift
@@ -1,0 +1,83 @@
+import CoreLocation
+import Foundation
+
+protocol LocationServiceProtocol {
+    func requestPermission() async -> Bool
+    func currentLocation() async -> HabitLocation?
+}
+
+@MainActor
+final class LocationService: NSObject, LocationServiceProtocol {
+    static let shared = LocationService()
+
+    private let manager = CLLocationManager()
+    private var awaitingPermission: CheckedContinuation<Bool, Never>?
+    private var awaitingCoordinates: CheckedContinuation<HabitLocation?, Never>?
+
+    private override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+    }
+
+    func requestPermission() async -> Bool {
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            return true
+        case .denied, .restricted:
+            return false
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                awaitingPermission = continuation
+                manager.requestWhenInUseAuthorization()
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    func currentLocation() async -> HabitLocation? {
+        let permitted = await requestPermission()
+        guard permitted else { return nil }
+
+        return await withCheckedContinuation { continuation in
+            awaitingCoordinates = continuation
+            manager.requestLocation()
+        }
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]
+    ) {
+        guard let coord = locations.first?.coordinate else { return }
+        let result = HabitLocation(lat: coord.latitude, lng: coord.longitude)
+        Task { @MainActor in
+            awaitingCoordinates?.resume(returning: result)
+            awaitingCoordinates = nil
+        }
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didFailWithError error: Error
+    ) {
+        print("LocationService didFail: \(error.localizedDescription)")
+        Task { @MainActor in
+            awaitingCoordinates?.resume(returning: nil)
+            awaitingCoordinates = nil
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            guard manager.authorizationStatus != .notDetermined else { return }
+            let granted = manager.authorizationStatus == .authorizedWhenInUse
+                || manager.authorizationStatus == .authorizedAlways
+            awaitingPermission?.resume(returning: granted)
+            awaitingPermission = nil
+        }
+    }
+}

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -11,15 +11,18 @@ final class HabitViewModel: ObservableObject {
     private let userId: String
     private let service: FirebaseServiceProtocol
     private let notificationService: NotificationServiceProtocol
+    private let locationService: LocationServiceProtocol
 
     init(
         userId: String,
         service: FirebaseServiceProtocol? = nil,
-        notificationService: NotificationServiceProtocol? = nil
+        notificationService: NotificationServiceProtocol? = nil,
+        locationService: LocationServiceProtocol? = nil
     ) {
         self.userId = userId
         self.service = service ?? FirebaseService.shared
         self.notificationService = notificationService ?? NotificationService.shared
+        self.locationService = locationService ?? LocationService.shared
     }
 
     func loadHabits() async {
@@ -109,11 +112,14 @@ final class HabitViewModel: ObservableObject {
         guard let habitId = habit.id else { return }
         guard !completedHabitIds.contains(habitId) else { return }
         completedHabitIds.insert(habitId)
+        
+        let location = await locationService.currentLocation()
 
         do {
             try await service.habitLogComplition(
                 habitId: habitId,
-                userId: habit.userId
+                userId: habit.userId,
+                location: location
             )
         } catch let saveError {
             completedHabitIds.remove(habitId)

--- a/daily_done/Views/Statistics/StatsView.swift
+++ b/daily_done/Views/Statistics/StatsView.swift
@@ -167,7 +167,7 @@ private struct MockFirebaseService: FirebaseServiceProtocol {
         ]
     }
     func createHabit(_ habit: Habit) async throws -> String { "" }
-    func habitLogComplition(habitId: String, userId: String) async throws {}
+    func habitLogComplition(habitId: String, userId: String, location: HabitLocation?) async throws {}
     func fetchTodayLogs(userId: String) async throws -> [HabitLog] { [] }
     func deleteHabit(habitId: String, userId: String) async throws {}
 


### PR DESCRIPTION
## 📝 Description
Added optional GPS coordinate capture when a habit is marked complete. LocationService requests when-in-use permission on first use, fetches a one-shot location fix, and stores the coordinates in Firestore alongside the HabitLog. If permission is denied the log saves normally without coordinates.

## 🎫 Related Issue
Closes #18

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="414" height="898" alt="Skärmavbild 2026-05-06 kl  15 24 43" src="https://github.com/user-attachments/assets/b154f88b-a787-4934-8cf6-6328bde4530d" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [ ] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
N/A — no UI changes in this ticket.

### Git
- [ ] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [ ] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [x] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Reset location permissions: Simulator menu → Device → Privacy → Location Services → Daily Done → Reset
2. Set a simulated location: Simulator menu → Features → Location → Apple
3. Complete a habit — iOS permission prompt should appear
4. Tap **Allow While Using App** — check Firestore `habitLogs` and confirm the new document has a `location` map with `lat` and `lng` fields
5. Reset permissions again, complete another habit and tap **Don't Allow** — confirm the log still saves successfully with no `location` field and no crash

## 💭 Additional Notes
- `kCLLocationAccuracyHundredMeters` is intentional — this is a completion snapshot, not movement tracking. 100m is accurate enough for "home/gym/café" context and saves battery. Higher accuracy is a DD-019 concern.
- `MockFirebaseService` in StatsView was updated to match the new `habitLogComplition` signature.
- The permission prompt only appears once per install. After granting, iOS goes straight to fetching coordinates on every completion.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [x] Database
- [ ] Notifications
- [x] Location services
- [ ] Charts/Statistics