### PR TITLE
feat [DD-038] Added SignUpView with email/password account creation

### DIFF
--- a/daily_done/Services/Firebase/FirebaseAuthService.swift
+++ b/daily_done/Services/Firebase/FirebaseAuthService.swift
@@ -5,6 +5,7 @@ protocol FirebaseAuthServiceProtocol {
     var authStatePublisher: AsyncStream<User?> { get }
     func signIn(email: String, password: String) async throws
     func signOut() throws
+    func createUser(email: String, password: String, displayName: String) async throws
 }
 
     actor FirebaseAuthService: FirebaseAuthServiceProtocol {
@@ -28,6 +29,15 @@ protocol FirebaseAuthServiceProtocol {
                 }
             }
         }
+        
+        func createUser(email: String, password: String, displayName: String) async throws {
+            let result = try await Auth.auth().createUser(withEmail: email, password: password)
+            let profileUpdate = result.user.createProfileChangeRequest()
+            profileUpdate.displayName = displayName
+            try await profileUpdate.commitChanges()
+            
+        }
+        
         func signIn(email: String, password: String) async throws {
             try await Auth.auth().signIn(withEmail: email, password: password)
         }

--- a/daily_done/ViewModels/AuthViewModel.swift
+++ b/daily_done/ViewModels/AuthViewModel.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 final class AuthViewModel: ObservableObject {
@@ -35,6 +35,21 @@ final class AuthViewModel: ObservableObject {
         }
     }
 
+    func signUp(email: String, password: String, displayName: String) async {
+        error = nil
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await service.createUser(
+                email: email,
+                password: password,
+                displayName: displayName
+            )
+        } catch {
+            self.error = .signUpFailed(error)
+        }
+    }
+
     func signIn(email: String, password: String) async {
         error = nil
         isLoading = true
@@ -62,6 +77,7 @@ extension AuthViewModel {
     enum AuthError: LocalizedError {
         case signInFailed(Error)
         case signOutFailed(Error)
+        case signUpFailed(Error)
 
         var errorDescription: String? {
             switch self {
@@ -69,6 +85,8 @@ extension AuthViewModel {
                 return "Could not sign in. Check your email and password."
             case .signOutFailed:
                 return "Could not sign out. Please try again."
+            case .signUpFailed(let error):
+                return "Could not create account. \(error.localizedDescription)"
             }
         }
     }

--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -144,7 +144,7 @@ struct SignInView: View {
                 )
             )
             .clipShape(RoundedRectangle(cornerRadius: 14))
-
+            .shadow(color: Color("brandPrimary").opacity(0.45), radius: 12, x: 0, y: 4)
             .opacity(email.isEmpty || password.isEmpty ? 0.6 : 1.0)
         }
 
@@ -159,11 +159,9 @@ struct SignInView: View {
             Button("Sign Up") { showSignUp = true }
                 .font(.caption)
                 .foregroundStyle(Color("brandPrimary"))
-                .font(.caption)
-                .foregroundStyle(Color("brandPrimary"))
         }
-        .sheet(isPresented: $showSignUp ) {
-            SignInView(vm: vm)
+        .sheet(isPresented: $showSignUp) {
+            SignUpView(vm: vm)
         }
     }
 

--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -6,8 +6,8 @@ struct SignInView: View {
 
     @State private var email = ""
     @State private var password = ""
+    @State private var showSignUp = false
 
-   
     @FocusState private var focusedField: Field?
 
     private enum Field { case email, password }
@@ -37,7 +37,7 @@ struct SignInView: View {
                     .padding(.bottom, 32)
             }
         }
-        
+
         .alert(
             "Sign In Failed",
             isPresented: Binding(
@@ -50,7 +50,6 @@ struct SignInView: View {
             Text(vm.error?.localizedDescription ?? "")
         }
     }
-
 
     private var logoSection: some View {
         VStack(spacing: 16) {
@@ -95,7 +94,6 @@ struct SignInView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-
     private var passwordField: some View {
         HStack(spacing: 12) {
             Image(systemName: "lock")
@@ -115,17 +113,16 @@ struct SignInView: View {
     private var forgotPasswordLink: some View {
         HStack {
             Spacer()
-            Button("Forgot password?") { }
+            Button("Forgot password?") {}
                 // TODO: implement forgot password flow later ticket
                 .font(.caption)
                 .foregroundStyle(Color("brandPrimary"))
         }
     }
 
-  
     private var signInButton: some View {
         Button {
-           
+
             Task { await signIn() }
         } label: {
             HStack(spacing: 8) {
@@ -159,10 +156,14 @@ struct SignInView: View {
             Text("Don't have an account?")
                 .font(.caption)
                 .foregroundStyle(Color("textSecondary"))
-            Button("Sign Up") { }
-                // TODO: navigate to sign-up screen
+            Button("Sign Up") { showSignUp = true }
                 .font(.caption)
                 .foregroundStyle(Color("brandPrimary"))
+                .font(.caption)
+                .foregroundStyle(Color("brandPrimary"))
+        }
+        .sheet(isPresented: $showSignUp ) {
+            SignInView(vm: vm)
         }
     }
 

--- a/daily_done/Views/Auth/SignUpView.swift
+++ b/daily_done/Views/Auth/SignUpView.swift
@@ -170,12 +170,9 @@ struct SignUpView: View {
             .padding(.vertical, 16)
             .background(
                 LinearGradient(
-                    colors: [
-                        Color("brandPrimary"),
-                        Color("brandPrimary").opacity(0.7),
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
+                    colors: [Color("brandPrimary"), Color("brandAccent")],
+                    startPoint: .leading,
+                    endPoint: .trailing
                 )
             )
             .clipShape(RoundedRectangle(cornerRadius: 14))

--- a/daily_done/Views/Auth/SignUpView.swift
+++ b/daily_done/Views/Auth/SignUpView.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+
+struct SignUpView: View {
+
+    @ObservedObject var vm: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var email = ""
+    @State private var password = ""
+    @State private var nameError: String?
+
+    @FocusState private var focusedField: Field?
+    private enum Field { case name, email, password }
+
+    var body: some View {
+        ZStack {
+            RadialGradient(
+                gradient: Gradient(colors: [
+                    Color("brandPrimary").opacity(0.25),
+                    Color("backgroundPrimary"),
+                ]),
+                center: .top,
+                startRadius: 0,
+                endRadius: 400
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+                headerSection
+                Spacer().frame(height: 40)
+
+                VStack(spacing: 12) {
+                    nameField
+                    emailField
+                    passwordField
+                }
+                .padding(.horizontal, 32)
+
+                Spacer().frame(height: 32)
+                signUpButton
+                    .padding(.horizontal, 32)
+                Spacer()
+                signInFooter
+                    .padding(.bottom, 32)
+            }
+        }
+        .alert(
+            "Sign Up Failed",
+            isPresented: Binding(
+                get: { vm.error != nil },
+                set: { if !$0 { vm.error = nil } }
+            )
+        ) {
+            Button("OK") { vm.error = nil }
+        } message: {
+            Text(vm.error?.localizedDescription ?? "")
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(Color("brandPrimary").opacity(0.2))
+                    .frame(width: 80, height: 80)
+                Circle()
+                    .fill(Color("brandPrimary").opacity(0.55))
+                    .frame(width: 60, height: 60)
+                Image(systemName: "person.badge.plus")
+                    .font(.system(size: 26, weight: .medium))
+                    .foregroundStyle(Color("textPrimary"))
+            }
+            VStack(spacing: 8) {
+                Text("Create account")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(Color("textPrimary"))
+                Text("Start tracking your habits")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color("textSecondary"))
+            }
+        }
+    }
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 12) {
+                Image(systemName: "person")
+                    .foregroundStyle(Color("textSecondary"))
+                    .frame(width: 20)
+                TextField("Full name", text: $name)
+                    .autocorrectionDisabled()
+                    .focused($focusedField, equals: .name)
+                    .foregroundStyle(Color("textPrimary"))
+                    .submitLabel(.next)
+                    .onSubmit { focusedField = .email }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 16)
+            .background(Color("backgroundSecondary"))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        nameError != nil
+                            ? Color.red.opacity(0.7)
+                            : Color("backgroundSecondary").opacity(0.6),
+                        lineWidth: 1
+                    )
+            )
+
+            if let nameError {
+                Text(nameError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.leading, 4)
+            }
+        }
+    }
+
+    private var emailField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "envelope")
+                .foregroundStyle(Color("textSecondary"))
+                .frame(width: 20)
+            TextField("Email address", text: $email)
+                .keyboardType(.emailAddress)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .focused($focusedField, equals: .email)
+                .foregroundStyle(Color("textPrimary"))
+                .submitLabel(.next)
+                .onSubmit { focusedField = .password }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 16)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var passwordField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "lock")
+                .foregroundStyle(Color("textSecondary"))
+                .frame(width: 20)
+            SecureField("Password", text: $password)
+                .focused($focusedField, equals: .password)
+                .foregroundStyle(Color("textPrimary"))
+                .submitLabel(.done)
+                .onSubmit { Task { await signUp() } }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 16)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var signUpButton: some View {
+        Button {
+            Task { await signUp() }
+        } label: {
+            HStack(spacing: 8) {
+                if vm.isLoading {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Sign Up").fontWeight(.semibold)
+                    Image(systemName: "arrow.right")
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                LinearGradient(
+                    colors: [
+                        Color("brandPrimary"),
+                        Color("brandPrimary").opacity(0.7),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(
+                color: Color("brandPrimary").opacity(0.45),
+                radius: 12,
+                x: 0,
+                y: 4
+            )
+            .opacity(
+                name.isEmpty || email.isEmpty || password.isEmpty ? 0.6 : 1.0
+            )
+        }
+        .disabled(
+            vm.isLoading || name.isEmpty || email.isEmpty || password.isEmpty
+        )
+    }
+
+    private var signInFooter: some View {
+        HStack(spacing: 4) {
+            Text("Already have an account?")
+                .font(.system(size: 14))
+                .foregroundStyle(Color("textSecondary"))
+            Button("Sign In") { dismiss() }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color("brandPrimary"))
+        }
+    }
+
+    private func signUp() async {
+        focusedField = nil
+        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+            nameError = "Please enter your name"
+            return
+        }
+        nameError = nil
+        await vm.signUp(email: email, password: password, displayName: name)
+    }
+}
+
+#Preview {
+    SignUpView(vm: AuthViewModel())
+        .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## 📝 Description
Adds the sign-up screen with name, email, and password fields. Tapping "Sign Up" creates a new Firebase Auth account via `AuthViewModel.signUp`, which automatically signs the user in and routes them to the main app through the existing session guard.

## 🎫 Related Issue
Closes #65

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="435" height="904" alt="Skärmavbild 2026-05-07 kl  13 17 38" src="https://github.com/user-attachments/assets/08a98396-c992-43b8-bf0e-7e511e37735b" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [x] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [x] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run on simulator — tap "Don't have an account? Sign Up" on the sign-in screen
2. Fill in a name, email, and password — verify the Sign Up button enables only when all fields are non-empty
3. Submit with a valid email/password — verify you land on the main app (ContentView)
4. Try submitting with a blank name — verify inline error message appears below the name field
5. Try signing up with an already-registered email — verify error alert appears with Firebase's message
6. Tap "Sign In" in the footer — verify the sheet dismisses and returns to SignInView

## 💭 Additional Notes
- `brandAccent` (orange) is intentionally kept as the gradient end on both auth buttons — design system color debt tracked in `TODO_REVIEW.md`
- `createProfileChangeRequest` is a Firebase SDK requirement for setting `displayName` after account creation; renamed locally to `profileUpdate` for clarity

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics