### PR TITLE
feat [DD-037] Added Forgot Password Flow With Reset Email and Confirmation

### DIFF
--- a/daily_done/Services/Firebase/FirebaseAuthService.swift
+++ b/daily_done/Services/Firebase/FirebaseAuthService.swift
@@ -5,45 +5,55 @@ protocol FirebaseAuthServiceProtocol {
     var authStatePublisher: AsyncStream<User?> { get }
     func signIn(email: String, password: String) async throws
     func signOut() throws
-    func createUser(email: String, password: String, displayName: String) async throws
+    func createUser(email: String, password: String, displayName: String)
+        async throws
+    func sendPasswordReset(email: String) async throws
 }
 
-    actor FirebaseAuthService: FirebaseAuthServiceProtocol {
+actor FirebaseAuthService: FirebaseAuthServiceProtocol {
 
-        nonisolated var authStatePublisher: AsyncStream<User?> {
-            AsyncStream { continuation in
-                let handle = Auth.auth().addStateDidChangeListener {
-                    _,
-                    firebaseUser in
-                    let user = firebaseUser.map {
-                        User(
-                            id: $0.uid,
-                            email: $0.email,
-                            displayName: $0.displayName
-                        )
-                    }
-                    continuation.yield(user)
+    nonisolated var authStatePublisher: AsyncStream<User?> {
+        AsyncStream { continuation in
+            let handle = Auth.auth().addStateDidChangeListener {
+                _,
+                firebaseUser in
+                let user = firebaseUser.map {
+                    User(
+                        id: $0.uid,
+                        email: $0.email,
+                        displayName: $0.displayName
+                    )
                 }
-                continuation.onTermination = { _ in
-                    Auth.auth().removeStateDidChangeListener(handle)
-                }
+                continuation.yield(user)
             }
-        }
-        
-        func createUser(email: String, password: String, displayName: String) async throws {
-            let result = try await Auth.auth().createUser(withEmail: email, password: password)
-            let profileUpdate = result.user.createProfileChangeRequest()
-            profileUpdate.displayName = displayName
-            try await profileUpdate.commitChanges()
-            
-        }
-        
-        func signIn(email: String, password: String) async throws {
-            try await Auth.auth().signIn(withEmail: email, password: password)
-        }
-
-        nonisolated func signOut() throws {
-            try Auth.auth().signOut()
+            continuation.onTermination = { _ in
+                Auth.auth().removeStateDidChangeListener(handle)
+            }
         }
     }
 
+    func createUser(email: String, password: String, displayName: String)
+        async throws
+    {
+        let result = try await Auth.auth().createUser(
+            withEmail: email,
+            password: password
+        )
+        let profileUpdate = result.user.createProfileChangeRequest()
+        profileUpdate.displayName = displayName
+        try await profileUpdate.commitChanges()
+
+    }
+
+    func signIn(email: String, password: String) async throws {
+        try await Auth.auth().signIn(withEmail: email, password: password)
+    }
+
+    nonisolated func signOut() throws {
+        try Auth.auth().signOut()
+    }
+
+    func sendPasswordReset(email: String) async throws {
+        try await Auth.auth().sendPasswordReset(withEmail: email)
+    }
+}

--- a/daily_done/ViewModels/AuthViewModel.swift
+++ b/daily_done/ViewModels/AuthViewModel.swift
@@ -76,8 +76,6 @@ final class AuthViewModel: ObservableObject {
     func sendPasswordReset(email: String) async {
         error = nil
         resetEmailSent = false
-        isLoading = true
-        defer { isLoading = false }
         do {
             try await service.sendPasswordReset(email: email)
             resetEmailSent = true

--- a/daily_done/ViewModels/AuthViewModel.swift
+++ b/daily_done/ViewModels/AuthViewModel.swift
@@ -9,6 +9,7 @@ final class AuthViewModel: ObservableObject {
     @Published var displayName: String?
     @Published var error: AuthError?
     @Published var isLoading: Bool = true
+    @Published var resetEmailSent: Bool = false
 
     private let service: FirebaseAuthServiceProtocol
     private var listenerTask: Task<Void, Never>?
@@ -71,6 +72,19 @@ final class AuthViewModel: ObservableObject {
             print("AuthViewModel signOut failed: \(error.localizedDescription)")
         }
     }
+
+    func sendPasswordReset(email: String) async {
+        error = nil
+        resetEmailSent = false
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await service.sendPasswordReset(email: email)
+            resetEmailSent = true
+        } catch {
+            self.error = .resetFailed(error)
+        }
+    }
 }
 
 extension AuthViewModel {
@@ -78,6 +92,7 @@ extension AuthViewModel {
         case signInFailed(Error)
         case signOutFailed(Error)
         case signUpFailed(Error)
+        case resetFailed(Error)
 
         var errorDescription: String? {
             switch self {
@@ -87,6 +102,8 @@ extension AuthViewModel {
                 return "Could not sign out. Please try again."
             case .signUpFailed(let error):
                 return "Could not create account. \(error.localizedDescription)"
+            case .resetFailed:
+                return "Could not send reset email. Check that the address is correct."
             }
         }
     }

--- a/daily_done/Views/Auth/ForgotPasswordSheet.swift
+++ b/daily_done/Views/Auth/ForgotPasswordSheet.swift
@@ -6,6 +6,7 @@ struct ForgotPasswordSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var email = ""
+    @State private var isSubmitting = false
     @FocusState private var emailFocused: Bool
 
     var body: some View {
@@ -24,8 +25,6 @@ struct ForgotPasswordSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
-                        vm.resetEmailSent = false
-                        vm.error = nil
                         dismiss()
                     }
                 }
@@ -74,7 +73,7 @@ struct ForgotPasswordSheet: View {
                 Task { await submit() }
             } label: {
                 HStack(spacing: 8) {
-                    if vm.isLoading {
+                    if isSubmitting {
                         ProgressView().tint(.white)
                     } else {
                         Text("Send Reset Link").fontWeight(.semibold)
@@ -95,7 +94,7 @@ struct ForgotPasswordSheet: View {
                 .shadow(color: Color("brandPrimary").opacity(0.45), radius: 12, x: 0, y: 4)
                 .opacity(email.isEmpty ? 0.6 : 1.0)
             }
-            .disabled(vm.isLoading || email.isEmpty)
+            .disabled(isSubmitting || email.isEmpty)
             .padding(.horizontal, 32)
         }
         .padding(.top, 32)
@@ -105,7 +104,7 @@ struct ForgotPasswordSheet: View {
 
     private var successView: some View {
         VStack(spacing: 20) {
-            Image(systemName: "envelope.badge.checkmark")
+            Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 56))
                 .foregroundStyle(Color("brandPrimary"))
 
@@ -120,7 +119,6 @@ struct ForgotPasswordSheet: View {
                 .padding(.horizontal, 32)
 
             Button("Done") {
-                vm.resetEmailSent = false
                 dismiss()
             }
             .font(.body).fontWeight(.semibold)
@@ -133,6 +131,8 @@ struct ForgotPasswordSheet: View {
 
     private func submit() async {
         emailFocused = false
+        isSubmitting = true
+        defer { isSubmitting = false }
         await vm.sendPasswordReset(email: email)
     }
 }

--- a/daily_done/Views/Auth/ForgotPasswordSheet.swift
+++ b/daily_done/Views/Auth/ForgotPasswordSheet.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct ForgotPasswordSheet: View {
+
+    @ObservedObject var vm: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var email = ""
+    @FocusState private var emailFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color("backgroundPrimary").ignoresSafeArea()
+
+                if vm.resetEmailSent {
+                    successView
+                } else {
+                    formView
+                }
+            }
+            .navigationTitle("Reset Password")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        vm.resetEmailSent = false
+                        vm.error = nil
+                        dismiss()
+                    }
+                }
+            }
+            .alert(
+                "Reset Failed",
+                isPresented: Binding(
+                    get: { vm.error != nil },
+                    set: { if !$0 { vm.error = nil } }
+                )
+            ) {
+                Button("OK") { vm.error = nil }
+            } message: {
+                Text(vm.error?.localizedDescription ?? "")
+            }
+        }
+    }
+
+    private var formView: some View {
+        VStack(spacing: 24) {
+            Text("Enter the email address for your account and we'll send you a reset link.")
+                .font(.body)
+                .foregroundStyle(Color("textSecondary"))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            HStack(spacing: 12) {
+                Image(systemName: "envelope")
+                    .foregroundStyle(Color("textSecondary"))
+                    .frame(width: 20)
+                TextField("Email address", text: $email)
+                    .keyboardType(.emailAddress)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .focused($emailFocused)
+                    .foregroundStyle(Color("textPrimary"))
+                    .submitLabel(.send)
+                    .onSubmit { Task { await submit() } }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 16)
+            .background(Color("backgroundSecondary"))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 32)
+
+            Button {
+                Task { await submit() }
+            } label: {
+                HStack(spacing: 8) {
+                    if vm.isLoading {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("Send Reset Link").fontWeight(.semibold)
+                        Image(systemName: "paperplane")
+                    }
+                }
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    LinearGradient(
+                        colors: [Color("brandPrimary"), Color("brandAccent")],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: Color("brandPrimary").opacity(0.45), radius: 12, x: 0, y: 4)
+                .opacity(email.isEmpty ? 0.6 : 1.0)
+            }
+            .disabled(vm.isLoading || email.isEmpty)
+            .padding(.horizontal, 32)
+        }
+        .padding(.top, 32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        
+    }
+
+    private var successView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "envelope.badge.checkmark")
+                .font(.system(size: 56))
+                .foregroundStyle(Color("brandPrimary"))
+
+            Text("Check your inbox")
+                .font(.title2).fontWeight(.bold)
+                .foregroundStyle(Color("textPrimary"))
+
+            Text("A reset link has been sent to \(email). Check your inbox (and spam folder).")
+                .font(.body)
+                .foregroundStyle(Color("textSecondary"))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button("Done") {
+                vm.resetEmailSent = false
+                dismiss()
+            }
+            .font(.body).fontWeight(.semibold)
+            .foregroundStyle(Color("brandPrimary"))
+            .padding(.top, 8)
+        }
+        .padding(.top, 48)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private func submit() async {
+        emailFocused = false
+        await vm.sendPasswordReset(email: email)
+    }
+}
+
+#Preview {
+    ForgotPasswordSheet(vm: AuthViewModel())
+        .preferredColorScheme(.dark)
+}

--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -118,7 +118,10 @@ struct SignInView: View {
                 .font(.caption)
                 .foregroundStyle(Color("brandPrimary"))
         }
-        .sheet(isPresented: $showForgotPassword) {
+        .sheet(isPresented: $showForgotPassword, onDismiss: {
+            vm.resetEmailSent = false
+            vm.error = nil
+        }) {
             ForgotPasswordSheet(vm: vm)
         }
     }

--- a/daily_done/Views/Auth/SignInView.swift
+++ b/daily_done/Views/Auth/SignInView.swift
@@ -7,6 +7,7 @@ struct SignInView: View {
     @State private var email = ""
     @State private var password = ""
     @State private var showSignUp = false
+    @State private var showForgotPassword = false
 
     @FocusState private var focusedField: Field?
 
@@ -113,10 +114,12 @@ struct SignInView: View {
     private var forgotPasswordLink: some View {
         HStack {
             Spacer()
-            Button("Forgot password?") {}
-                // TODO: implement forgot password flow later ticket
+            Button("Forgot password?") { showForgotPassword = true }
                 .font(.caption)
                 .foregroundStyle(Color("brandPrimary"))
+        }
+        .sheet(isPresented: $showForgotPassword) {
+            ForgotPasswordSheet(vm: vm)
         }
     }
 
@@ -144,7 +147,12 @@ struct SignInView: View {
                 )
             )
             .clipShape(RoundedRectangle(cornerRadius: 14))
-            .shadow(color: Color("brandPrimary").opacity(0.45), radius: 12, x: 0, y: 4)
+            .shadow(
+                color: Color("brandPrimary").opacity(0.45),
+                radius: 12,
+                x: 0,
+                y: 4
+            )
             .opacity(email.isEmpty || password.isEmpty ? 0.6 : 1.0)
         }
 


### PR DESCRIPTION
## 📝 Description
Adds complete forgot password support: `FirebaseAuthService` sends the reset email via Firebase Auth, `AuthViewModel` manages success/error state, and `ForgotPasswordSheet` presents an email input form followed by a success confirmation screen — triggered from the "Forgot password?" button in `SignInView`.

## 🎫 Related Issue
Closes #64

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<img width="435" height="908" alt="Skärmavbild 2026-05-07 kl  18 10 05" src="https://github.com/user-attachments/assets/31041225-a977-4242-be12-1f1f46233c82" />
<img width="435" height="908" alt="Skärmavbild 2026-05-07 kl  18 27 26" src="https://github.com/user-attachments/assets/f115ead2-9511-4a1a-b0a4-9ee7f252f85a" />


## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [x] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary) — no new collections, Auth only
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [ ] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `dev`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Open the app and navigate to the Sign In screen
2. Tap "Forgot password?" — `ForgotPasswordSheet` should appear as a bottom sheet with an email field
3. Enter a valid email and tap "Send Reset Link" — loading spinner should appear, then the success screen ("Check your inbox") should show without closing the sheet
4. Tap Done — sheet closes, state resets
5. Tap "Forgot password?" again — should open to the email input form, not the success screen
6. Swipe the sheet down to dismiss after a successful send — re-opening should also show the email input form, not the success screen
7. Enter an invalid/unregistered email — "Reset Failed" error alert should appear with a clear message

## 💭 Additional Notes
`sendPasswordReset` does not touch `vm.isLoading` — the shared loading flag is observed at the app root (`daily_doneApp`) and setting it to `true` mid-flow would destroy `SignInView`, dismissing the sheet. The sheet manages its own spinner via `@State private var isSubmitting`. Sheet state cleanup is centralised in `onDismiss` on the sheet presenter in `SignInView`, so swipe-to-dismiss also resets correctly. SF Symbol changed from `envelope.badge.checkmark` (iOS 17+) to `checkmark.circle.fill` (iOS 13+).

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics