### PR TITLE
refactor [DD-XXX] Removed userId Prop Drilling via Custom @Environment Key

### DIFF
--- a/daily_done/App/ContentView.swift
+++ b/daily_done/App/ContentView.swift
@@ -1,34 +1,33 @@
 import SwiftUI
 
 struct ContentView: View {
-    let userId: String
     @ObservedObject var auth: AuthViewModel
     @AppStorage(UserDefaultsKey.darkModeEnabled) private var darkModeEnabled = true
 
     var body: some View {
         TabView {
             NavigationStack {
-                HabitListView(userId: userId)
+                HabitListView()
             }
             .tabItem {
                 Label("Habits", systemImage: "checkmark.circle")
             }
 
             NavigationStack {
-                StatsView(userId: userId)
+                StatsView()
             }
             .tabItem {
                 Label("Stats", systemImage: "chart.bar")
             }
             NavigationStack {
-                MapView(userId: userId)
+                MapView()
             }
             .tabItem {
                 Label("Map", systemImage: "map")
             }
 
             NavigationStack {
-                ProfileView(userId: userId, vm: auth)
+                ProfileView(vm: auth)
             }
             .tabItem {
                 Label("Profile", systemImage: "person.circle")
@@ -39,5 +38,6 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(userId: "preview-user", auth: AuthViewModel())
+    ContentView(auth: AuthViewModel())
+        .environment(\.userId, "preview-user")
 }

--- a/daily_done/App/daily_doneApp.swift
+++ b/daily_done/App/daily_doneApp.swift
@@ -23,7 +23,8 @@ struct daily_doneApp: App {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if auth.isSignedIn, let userId = auth.userId {
-                ContentView(userId: userId, auth: auth)
+                ContentView(auth: auth)
+                    .environment(\.userId, userId)
 
             } else if !splashDissmised {
                 SplashView(onGetStarted: { splashDissmised = true })

--- a/daily_done/Environment/UserIdEnvironmentKey.swift
+++ b/daily_done/Environment/UserIdEnvironmentKey.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct UserIdKey: EnvironmentKey {
+    static let defaultValue: String = ""
+}
+
+extension EnvironmentValues {
+    var userId: String {
+        get { self[UserIdKey.self] }
+        set { self[UserIdKey.self] = newValue }
+    }
+}

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -11,7 +11,7 @@ final class HabitViewModel: ObservableObject {
     @Published var error: HabitError?
     @Published var completedHabitIds: Set<String> = []
 
-    private let userId: String
+    private var userId: String = ""
     private let service: FirebaseServiceProtocol
     private let notificationService: NotificationServiceProtocol
     private let locationService: LocationServiceProtocol
@@ -19,7 +19,7 @@ final class HabitViewModel: ObservableObject {
     // MARK: - Init
 
     init(
-        userId: String,
+        userId: String = "" ,
         service: FirebaseServiceProtocol? = nil,
         notificationService: NotificationServiceProtocol? = nil,
         locationService: LocationServiceProtocol? = nil
@@ -161,6 +161,10 @@ final class HabitViewModel: ObservableObject {
             )
 
         }
+    }
+    
+    func configure(userId: String) {
+        self.userId = userId
     }
 }
 

--- a/daily_done/ViewModels/MapViewModel.swift
+++ b/daily_done/ViewModels/MapViewModel.swift
@@ -11,10 +11,10 @@ final class MapViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var error: String? = nil
 
-    private let userId: String
+    private var userId: String = ""
     private let service: FirebaseServiceProtocol
 
-    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+    init(userId: String = "", service: FirebaseServiceProtocol? = nil) {
         self.userId = userId
         self.service = service ?? FirebaseService.shared
     }
@@ -64,5 +64,9 @@ final class MapViewModel: ObservableObject {
             error = "Could not load map data. Please try again."
             print("MapViewModel loadNearbyHabits failed: \(fetchError.localizedDescription)")
         }
+    }
+    
+    func configure(userId: String) {
+        self.userId = userId
     }
 }

--- a/daily_done/ViewModels/StatsViewModel.swift
+++ b/daily_done/ViewModels/StatsViewModel.swift
@@ -11,9 +11,9 @@ final class StatsViewModel: ObservableObject {
     @Published var error: StatsError?
 
     private let service: FirebaseServiceProtocol
-    private let userId: String
+    private var userId: String = ""
 
-    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+    init(userId: String = "", service: FirebaseServiceProtocol? = nil) {
         self.userId = userId
         self.service = service ?? FirebaseService.shared
     }
@@ -66,5 +66,10 @@ final class StatsViewModel: ObservableObject {
             }.count
             return DayStat(id: date, count: count)
         }.reversed()
+    }
+    
+    
+    func configure(userId: String) {
+        self.userId = userId
     }
 }

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -1,12 +1,11 @@
 import SwiftUI
 
 struct HabitListView: View {
-    @StateObject private var vm: HabitViewModel
+    @StateObject private var vm = HabitViewModel()
+    @Environment(\.userId) private var userId
     @State private var showCreateSheet = false
 
-    init(userId: String) {
-        _vm = StateObject(wrappedValue: HabitViewModel(userId: userId))
-    }
+    init() { }
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -34,6 +33,7 @@ struct HabitListView: View {
             CreateHabitSheet(vm: vm)
         }
         .task {
+            vm.configure(userId: userId)
             await vm.loadHabits()
         }
         .alert(
@@ -198,6 +198,7 @@ struct HabitListView: View {
 }
 
 #Preview {
-    HabitListView(userId: "preview-user")
+    HabitListView()
+        .environment(\.userId, "preview-user")
         .preferredColorScheme(.dark)
 }

--- a/daily_done/Views/Map/MapView.swift
+++ b/daily_done/Views/Map/MapView.swift
@@ -3,9 +3,12 @@ import SwiftUI
 
 struct MapView: View {
     @StateObject private var vm: MapViewModel
+    @Environment(\.userId) private var userId
 
-    init(userId: String, service: FirebaseServiceProtocol = FirebaseService.shared) {
-        _vm = StateObject(wrappedValue: MapViewModel(userId: userId, service: service))
+    init(service: FirebaseServiceProtocol = FirebaseService.shared) {
+        _vm = StateObject(
+            wrappedValue: MapViewModel(service: service)
+        )
     }
 
     @State private var selectedAnnotation: HabitLogAnnotation?
@@ -17,15 +20,21 @@ struct MapView: View {
         }
         .navigationTitle("Habit Map")
         .navigationBarTitleDisplayMode(.inline)
-        .task { await vm.loadNearbyHabits() }
+        .task {
+            vm.configure(userId: userId)
+            await vm.loadNearbyHabits()
+        }
         .sheet(item: $selectedAnnotation) { annotation in
             annotationDetail(annotation)
                 .presentationDetents([.fraction(0.3)])
         }
-        .alert("Error", isPresented: Binding(
-            get: { vm.error != nil },
-            set: { if !$0 { vm.error = nil } }
-        )) {
+        .alert(
+            "Error",
+            isPresented: Binding(
+                get: { vm.error != nil },
+                set: { if !$0 { vm.error = nil } }
+            )
+        ) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(vm.error ?? "")
@@ -33,7 +42,8 @@ struct MapView: View {
         .overlay {
             if vm.isLoading {
                 ProgressView()
-            } else if vm.filteredAnnotations.isEmpty && !vm.annotations.isEmpty {
+            } else if vm.filteredAnnotations.isEmpty && !vm.annotations.isEmpty
+            {
                 emptyFilterState
             } else if vm.annotations.isEmpty {
                 emptyNoLogsState
@@ -47,7 +57,9 @@ struct MapView: View {
         Map {
             ForEach(vm.filteredAnnotations) { item in
                 Annotation(item.habitName, coordinate: item.coordinate) {
-                    Button { selectedAnnotation = item } label: {
+                    Button {
+                        selectedAnnotation = item
+                    } label: {
                         Image(systemName: "mappin.circle.fill")
                             .font(.title)
                             .foregroundStyle(Color("brandPrimary"))
@@ -85,8 +97,12 @@ struct MapView: View {
                 .fontWeight(isSelected ? .semibold : .regular)
                 .padding(.horizontal, DesignSystem.Spacing.md)
                 .padding(.vertical, DesignSystem.Spacing.sm)
-                .background(isSelected ? Color("brandPrimary") : Color(.systemGray5))
-                .foregroundStyle(isSelected ? Color.white : Color("textPrimary"))
+                .background(
+                    isSelected ? Color("brandPrimary") : Color(.systemGray5)
+                )
+                .foregroundStyle(
+                    isSelected ? Color.white : Color("textPrimary")
+                )
                 .clipShape(Capsule())
         }
         .accessibilityLabel(label)
@@ -114,7 +130,9 @@ struct MapView: View {
         ContentUnavailableView(
             "No pins for this habit",
             systemImage: "mappin.slash",
-            description: Text("This habit has no logged locations. Try completing it with location enabled.")
+            description: Text(
+                "This habit has no logged locations. Try completing it with location enabled."
+            )
         )
     }
 
@@ -122,15 +140,18 @@ struct MapView: View {
         ContentUnavailableView(
             "No locations logged yet",
             systemImage: "map",
-            description: Text("Complete habits to start seeing your locations on the map.")
+            description: Text(
+                "Complete habits to start seeing your locations on the map."
+            )
         )
     }
 }
 
 #Preview {
     NavigationStack {
-        MapView(userId: "preview-user", service: MockMapService())
+        MapView(service: MockMapService())
     }
+    .environment(\.userId, "preview-user")
 }
 
 private struct MockMapService: FirebaseServiceProtocol {
@@ -177,33 +198,97 @@ private struct MockMapService: FirebaseServiceProtocol {
                 totalCompletions: 10,
                 isReminderEnabled: false,
                 reminderTime: nil
-            )
+            ),
         ]
     }
 
     func fetchAllLogs(userId: String) async throws -> [HabitLog] {
         [
             // Morning Run — 4 pins around Stockholm
-            HabitLog(id: "log-1", habitId: "habit-1", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3293, lng: 18.0686)),
-            HabitLog(id: "log-2", habitId: "habit-1", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3340, lng: 18.0750)),
-            HabitLog(id: "log-3", habitId: "habit-1", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3250, lng: 18.0600)),
-            HabitLog(id: "log-4", habitId: "habit-1", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3310, lng: 18.0810)),
+            HabitLog(
+                id: "log-1",
+                habitId: "habit-1",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3293, lng: 18.0686)
+            ),
+            HabitLog(
+                id: "log-2",
+                habitId: "habit-1",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3340, lng: 18.0750)
+            ),
+            HabitLog(
+                id: "log-3",
+                habitId: "habit-1",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3250, lng: 18.0600)
+            ),
+            HabitLog(
+                id: "log-4",
+                habitId: "habit-1",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3310, lng: 18.0810)
+            ),
 
             // Read 20 min — 3 pins (closer together, indoor habit)
-            HabitLog(id: "log-5", habitId: "habit-2", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3320, lng: 18.0640)),
-            HabitLog(id: "log-6", habitId: "habit-2", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3280, lng: 18.0700)),
-            HabitLog(id: "log-7", habitId: "habit-2", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3300, lng: 18.0720)),
+            HabitLog(
+                id: "log-5",
+                habitId: "habit-2",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3320, lng: 18.0640)
+            ),
+            HabitLog(
+                id: "log-6",
+                habitId: "habit-2",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3280, lng: 18.0700)
+            ),
+            HabitLog(
+                id: "log-7",
+                habitId: "habit-2",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3300, lng: 18.0720)
+            ),
 
             // Meditate — 2 pins + 1 with no location (tests compactMap)
-            HabitLog(id: "log-8", habitId: "habit-3", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3270, lng: 18.0660)),
-            HabitLog(id: "log-9", habitId: "habit-3", userId: userId, completedAt: Date(), location: HabitLocation(lat: 59.3350, lng: 18.0780)),
-            HabitLog(id: "log-10", habitId: "habit-3", userId: userId, completedAt: Date(), location: nil)
+            HabitLog(
+                id: "log-8",
+                habitId: "habit-3",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3270, lng: 18.0660)
+            ),
+            HabitLog(
+                id: "log-9",
+                habitId: "habit-3",
+                userId: userId,
+                completedAt: Date(),
+                location: HabitLocation(lat: 59.3350, lng: 18.0780)
+            ),
+            HabitLog(
+                id: "log-10",
+                habitId: "habit-3",
+                userId: userId,
+                completedAt: Date(),
+                location: nil
+            ),
         ]
     }
 
     // Required by protocol — not used in MapView
     func createHabit(_ habit: Habit) async throws -> String { "" }
-    func habitLogCompletion(habitId: String, userId: String, location: HabitLocation?) async throws {}
+    func habitLogCompletion(
+        habitId: String,
+        userId: String,
+        location: HabitLocation?
+    ) async throws {}
     func fetchTodayLogs(userId: String) async throws -> [HabitLog] { [] }
     func deleteHabit(habitId: String, userId: String) async throws {}
 }

--- a/daily_done/Views/Profile/ProfileView.swift
+++ b/daily_done/Views/Profile/ProfileView.swift
@@ -4,10 +4,12 @@ struct ProfileView: View {
 
     @ObservedObject var vm: AuthViewModel
     @StateObject private var statsVM: StatsViewModel
+    @Environment(\.userId) private var userId
+
     
-    init(userId: String, vm: AuthViewModel) {
+    init(vm: AuthViewModel) {
         self.vm = vm
-        _statsVM = StateObject(wrappedValue: StatsViewModel(userId: userId))
+        _statsVM = StateObject(wrappedValue: StatsViewModel())
     }
 
     @AppStorage(UserDefaultsKey.notificationsEnabled) private var notificationsEnabled = true
@@ -34,6 +36,7 @@ struct ProfileView: View {
         .navigationTitle("Profile")
         .navigationBarTitleDisplayMode(.large)
         .task {
+            statsVM.configure(userId: userId)
             await statsVM.loadStats()
         }
         .toolbar {
@@ -199,7 +202,8 @@ private struct SettingsRow: View {
 
 #Preview {
     NavigationStack {
-        ProfileView(userId: "preview-user" ,vm: AuthViewModel())
+        ProfileView(vm: AuthViewModel())
     }
+    .environment(\.userId, "preview-user")
     .preferredColorScheme(.dark)
 }

--- a/daily_done/Views/Statistics/StatsView.swift
+++ b/daily_done/Views/Statistics/StatsView.swift
@@ -2,17 +2,20 @@ import SwiftUI
 
 struct StatsView: View {
 
-    init(userId: String, service: FirebaseServiceProtocol? = nil) {
+    init(service: FirebaseServiceProtocol? = nil) {
         _vm = StateObject(
-            wrappedValue: StatsViewModel(userId: userId, service: service)
+            wrappedValue: StatsViewModel(service: service)
         )
     }
     @StateObject private var vm: StatsViewModel
+    @Environment(\.userId) private var userId
+
 
     var body: some View {
         contentView
             .navigationTitle("Statistics")
             .task {
+                vm.configure(userId: userId)
                 await vm.loadStats()
             }
             .alert(
@@ -137,9 +140,8 @@ private struct HabitStreakRow: View {
 // MARK: - Previews
 
 #Preview {
-    NavigationStack {
-        StatsView(userId: "preview-user")
-    }
+    NavigationStack { StatsView() }
+        .environment(\.userId, "preview-user")
 }
 
 #if DEBUG
@@ -213,7 +215,6 @@ private struct MockFirebaseService: FirebaseServiceProtocol {
 #endif
 
 #Preview("Stats — with data") {
-    NavigationStack {
-        StatsView(userId: "preview-user", service: MockFirebaseService())
-    }
+    NavigationStack { StatsView(service: MockFirebaseService()) }
+        .environment(\.userId, "preview-user")
 }


### PR DESCRIPTION
## 📝 Description
Removed `userId` prop drilling across the view hierarchy by introducing a custom `@Environment` key. `userId` is now set once at the app root and read directly in any view that needs it, eliminating `ContentView` acting as a pass-through carrier.

## 🎫 Related Issue
No ticket — housekeeping refactor identified during architecture audit.

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
N/A — no visual changes.

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [x] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [x] Functionality has been tested manually
- [x] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [x] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [ ] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [ ] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Build and run the app — sign in with a valid account
2. Verify all four tabs (Habits, Stats, Map, Profile) load data correctly
3. Sign out and sign back in — confirm data reloads without issues
4. Check that creating and completing a habit still works end-to-end

## 💭 Additional Notes
ViewModels gained a `configure(userId:)` method as a workaround for the SwiftUI constraint that `@StateObject` initializes before `@Environment` is injected. `userId` defaults to `""` at init, then gets set via `.task` before any data fetch runs.

## 📊 Impact
- [x] Core functionality
- [ ] UI/UX
- [ ] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics