### PR TITLE
feat [DD-039] Added EditHabitSheet with pre-filled form, save, and delete confirmation

### DIFF
--- a/daily_done/Services/Firebase/FirebaseService.swift
+++ b/daily_done/Services/Firebase/FirebaseService.swift
@@ -14,6 +14,7 @@ protocol FirebaseServiceProtocol {
     func fetchTodayLogs(userId: String) async throws -> [HabitLog]
     func fetchAllLogs(userId: String) async throws -> [HabitLog]
     func deleteHabit(habitId: String, userId: String) async throws
+    func updateHabit(_ habit: Habit) async throws
 }
 
 // MARK: - Service
@@ -35,6 +36,19 @@ actor FirebaseService: FirebaseServiceProtocol {
     }
 
     private init() {}
+
+    // MARK: - UPDATE
+
+    func updateHabit(_ habit: Habit) async throws {
+        guard let habitId = habit.id else {
+            throw FirebaseServiceError.invalidId
+        }
+        let ref = db.collection(Collection.habits).document(habitId)
+        let data = try await MainActor.run {
+            try Firestore.Encoder().encode(habit)
+        }
+        try await ref.setData(data, merge: true)
+    }
 
     // MARK: - CREATE
 

--- a/daily_done/Utilities/Errors/FirebaseServiceError.swift
+++ b/daily_done/Utilities/Errors/FirebaseServiceError.swift
@@ -2,11 +2,14 @@ import Foundation
 
 enum FirebaseServiceError: LocalizedError {
     case invalidDate
+    case invalidId
 
     var errorDescription: String? {
         switch self {
         case .invalidDate:
             return "Could not calculate a valid date range. Please try again."
+        case .invalidId:
+            return "Habit ID is missing. Please reload and try again."
         }
     }
 }

--- a/daily_done/ViewModels/HabitViewModel.swift
+++ b/daily_done/ViewModels/HabitViewModel.swift
@@ -164,6 +164,20 @@ final class HabitViewModel: ObservableObject {
         }
     }
     
+    func updateHabit(_ habit: Habit) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            try await service.updateHabit(habit)
+            if let idx = habits.firstIndex(where: { $0.id == habit.id }) {
+                habits[idx] = habit
+            }
+        } catch {
+            self.error = .saveFailed(error)
+        }
+    }
+
     func configure(userId: String) {
         self.userId = userId
     }

--- a/daily_done/Views/Habits/EditHabitSheet.swift
+++ b/daily_done/Views/Habits/EditHabitSheet.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+struct EditHabitSheet: View {
+    @ObservedObject var vm: HabitViewModel
+    let habit: Habit
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var selectedCategory: HabitCategory
+    @State private var selectedColorHex: String
+    @State private var selectedIcon: String
+
+    @State private var nameError: String?
+    @State private var saveError: String?
+    @State private var isSaving = false
+    @State private var isDeleting = false
+    @State private var showDeleteConfirmation = false
+
+    init(vm: HabitViewModel, habit: Habit) {
+        self.vm = vm
+        self.habit = habit
+        _name = State(initialValue: habit.name)
+        _selectedCategory = State(initialValue: habit.category)
+        _selectedColorHex = State(initialValue: habit.colorHex)
+        _selectedIcon = State(initialValue: habit.iconName)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    if let saveError {
+                        ErrorBannerView(message: saveError)
+                    }
+                    nameSection
+                    categorySection
+                    colorSection
+                    iconSection
+                    deleteSection
+                }
+                .padding(DesignSystem.Spacing.base)
+            }
+            .background(Color("backgroundSheet"))
+            .navigationTitle("Edit Habit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Color("textSecondary"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color("brandPrimary"))
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+            }
+            .alert("Delete Habit", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    Task { await delete() }
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("\"\(habit.name)\" will be permanently deleted.")
+            }
+        }
+    }
+
+    // MARK: - Name
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("HABIT NAME")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            TextField("Habit name", text: $name)
+                .padding(DesignSystem.Spacing.md)
+                .background(Color("backgroundSecondary"))
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.sm))
+                .foregroundStyle(Color("textPrimary"))
+            if let nameError {
+                Text(nameError)
+                    .font(.caption)
+                    .foregroundStyle(Color("destructive"))
+            }
+        }
+    }
+
+    // MARK: - Category
+
+    private var categorySection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("CATEGORY")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    ForEach(HabitCategory.allCases) { category in
+                        Button(category.rawValue.capitalized) {
+                            selectedCategory = category
+                        }
+                        .padding(.horizontal, DesignSystem.Spacing.base)
+                        .padding(.vertical, DesignSystem.Spacing.sm)
+                        .background(
+                            selectedCategory == category
+                                ? Color(hex: selectedColorHex)
+                                : Color("backgroundSecondary")
+                        )
+                        .foregroundStyle(
+                            selectedCategory == category
+                                ? Color("textPrimary")
+                                : Color("textSecondary")
+                        )
+                        .clipShape(Capsule())
+                        .accessibilityLabel("\(category.rawValue.capitalized)\(selectedCategory == category ? ", selected" : "")")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Color
+
+    private var colorSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("COLOR")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            HStack(spacing: DesignSystem.Spacing.md) {
+                ForEach(DesignSystem.HabitPalette.colors, id: \.self) { hex in
+                    Circle()
+                        .fill(Color(hex: hex))
+                        .frame(width: DesignSystem.Size.colorSwatch, height: DesignSystem.Size.colorSwatch)
+                        .overlay {
+                            if selectedColorHex == hex {
+                                Circle().strokeBorder(
+                                    Color("textPrimary"),
+                                    lineWidth: DesignSystem.Stroke.selection
+                                )
+                            }
+                        }
+                        .onTapGesture { selectedColorHex = hex }
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityLabel("Color\(selectedColorHex == hex ? ", selected" : "")")
+                }
+            }
+        }
+    }
+
+    // MARK: - Icon
+
+    private var iconSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("ICON")
+                .font(.caption)
+                .foregroundStyle(Color("textSecondary"))
+            HStack(spacing: DesignSystem.Spacing.md) {
+                ForEach(DesignSystem.HabitPalette.icons, id: \.self) { icon in
+                    ZStack {
+                        RoundedRectangle(cornerRadius: DesignSystem.Radius.md)
+                            .fill(
+                                selectedIcon == icon
+                                    ? Color(hex: selectedColorHex)
+                                    : Color("backgroundSecondary")
+                            )
+                            .frame(width: DesignSystem.Size.iconPickerTile, height: DesignSystem.Size.iconPickerTile)
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .foregroundStyle(
+                                selectedIcon == icon
+                                    ? Color("textPrimary")
+                                    : Color("textSecondary")
+                            )
+                            .onTapGesture { selectedIcon = icon }
+                    }
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Icon: \(icon)\(selectedIcon == icon ? ", selected" : "")")
+                }
+            }
+        }
+    }
+
+    // MARK: - Delete
+
+    private var deleteSection: some View {
+        Button {
+            showDeleteConfirmation = true
+        } label: {
+            if isDeleting {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            } else {
+                Text("Delete Habit")
+                    .frame(maxWidth: .infinity)
+                    .foregroundStyle(Color("destructive"))
+            }
+        }
+        .padding(DesignSystem.Spacing.base)
+        .background(Color("backgroundSecondary"))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.md))
+        .disabled(isDeleting || isSaving)
+        .accessibilityLabel("Delete habit")
+        .accessibilityHint("Asks for confirmation before deleting")
+    }
+
+    // MARK: - Actions
+
+    private func save() async {
+        nameError = nil
+        saveError = nil
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            nameError = "Habit name can't be empty."
+            return
+        }
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = habit
+        updated.name = trimmed
+        updated.category = selectedCategory
+        updated.colorHex = selectedColorHex
+        updated.iconName = selectedIcon
+
+        await vm.updateHabit(updated)
+
+        if vm.error == nil {
+            dismiss()
+        } else {
+            saveError = vm.error?.errorDescription
+            vm.error = nil
+        }
+    }
+
+    private func delete() async {
+        isDeleting = true
+        defer { isDeleting = false }
+        await vm.deleteHabit(habit)
+        dismiss()
+    }
+}
+
+#Preview {
+    EditHabitSheet(vm: HabitViewModel(userId: "preview-user"), habit: .preview)
+}

--- a/daily_done/Views/Habits/HabitListView.swift
+++ b/daily_done/Views/Habits/HabitListView.swift
@@ -4,6 +4,7 @@ struct HabitListView: View {
     @StateObject private var vm = HabitViewModel()
     @Environment(\.userId) private var userId
     @State private var showCreateSheet = false
+    @State private var habitToEdit: Habit? = nil
 
     init() { }
 
@@ -31,6 +32,9 @@ struct HabitListView: View {
 
         .sheet(isPresented: $showCreateSheet) {
             CreateHabitSheet(vm: vm)
+        }
+        .sheet(item: $habitToEdit) { habit in
+            EditHabitSheet(vm: vm, habit: habit)
         }
         .task {
             vm.configure(userId: userId)
@@ -144,6 +148,14 @@ struct HabitListView: View {
                     bottom: DesignSystem.Spacing.xs,
                     trailing: DesignSystem.Spacing.base
                 ))
+                .swipeActions(edge: .leading) {
+                    Button {
+                        habitToEdit = habit
+                    } label: {
+                        Label("Edit", systemImage: "pencil")
+                    }
+                    .tint(Color("brandPrimary"))
+                }
                 .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
                         Task { await vm.deleteHabit(habit) }

--- a/daily_done/Views/Map/MapView.swift
+++ b/daily_done/Views/Map/MapView.swift
@@ -291,4 +291,5 @@ private struct MockMapService: FirebaseServiceProtocol {
     ) async throws {}
     func fetchTodayLogs(userId: String) async throws -> [HabitLog] { [] }
     func deleteHabit(habitId: String, userId: String) async throws {}
+    func updateHabit(_ habit: Habit) async throws {}
 }

--- a/daily_done/Views/Statistics/StatsView/StatsView.swift
+++ b/daily_done/Views/Statistics/StatsView/StatsView.swift
@@ -183,6 +183,7 @@ private struct MockFirebaseService: FirebaseServiceProtocol {
     func habitLogCompletion(habitId: String, userId: String, location: HabitLocation?) async throws {}
     func fetchTodayLogs(userId: String) async throws -> [HabitLog] { [] }
     func deleteHabit(habitId: String, userId: String) async throws {}
+    func updateHabit(_ habit: Habit) async throws {}
 
     func fetchAllLogs(userId: String) async throws -> [HabitLog] {
         let calendar = Calendar.current


### PR DESCRIPTION
## 📝 Description
Added an Edit Habit sheet that opens pre-filled with a habit's current name, category, colour, and icon. Users can update any field and save back to Firestore, or permanently delete the habit via a destructive confirmation alert. Triggered via a leading swipe action on habit rows.

## 🎫 Related Issue
Closes #70

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## 📱 Screenshots/Videos
<!-- Add screenshots after testing on simulator -->

## ✅ Checklist

### Code Quality
- [x] Code follows the project's coding style
- [ ] No warnings in Xcode
- [x] Code is commented where needed
- [x] Folder structure is followed (Models/, Views/, ViewModels/)

### Testing
- [ ] Functionality has been tested manually
- [ ] App does not crash
- [x] Error handling works correctly
- [ ] Tested on iPhone and iPad (if relevant)

### Firebase/Backend
- [x] Firebase rules updated (if necessary)
- [x] No hardcoded API keys
- [x] Error handling for network failures exists

### UI/UX
- [ ] UI works on different screen sizes
- [ ] Dark mode works correctly
- [x] Accessibility labels added (if relevant)
- [ ] Animations are smooth

### Git
- [x] Branch is up to date with latest `main`
- [x] Commits have clear messages
- [x] No merge conflicts

### Documentation
- [ ] README updated (if necessary)
- [ ] Comments added for complex logic
- [ ] API documentation updated (if relevant)

## 🧪 How to Test
1. Open the app and navigate to the Habits tab — ensure you have at least one habit
2. Swipe right on a habit row — an "Edit" button (brand colour) should appear on the leading edge
3. Tap "Edit" — the sheet opens with the habit's current name, category, colour, and icon pre-selected
4. Change the name, pick a different category and colour, tap "Save" — verify the row updates immediately with no reload
5. Re-open the sheet and clear the name field — verify the Save button is disabled
6. Tap "Delete Habit" at the bottom — verify a confirmation alert appears naming the habit
7. Confirm the delete — verify the sheet dismisses and the habit is removed from the list
8. To test the error state: put the device in airplane mode and attempt to save — verify an error banner appears in the sheet

## 💭 Additional Notes
- `updateHabit` was added to `FirebaseServiceProtocol` — two preview mocks (`MockFirebaseService` in StatsView and `MockMapService` in MapView) required a no-op stub to conform to the updated protocol.
- `FirebaseServiceError.invalidId` was added to handle the guard on missing Firestore document ID in `updateHabit`.
- Reminder settings are intentionally preserved on edit (the sheet does not expose them) — the habit's existing `isReminderEnabled` and `reminderTime` values pass through unchanged on save.

## 📊 Impact
- [x] Core functionality
- [x] UI/UX
- [x] Database
- [ ] Notifications
- [ ] Location services
- [ ] Charts/Statistics